### PR TITLE
macOS 13.0 beta 3: fix date and add ipsw

### DIFF
--- a/iosFiles/macOS/22x - 13.x/22A5295h.json
+++ b/iosFiles/macOS/22x - 13.x/22A5295h.json
@@ -2,7 +2,7 @@
     "osStr": "macOS",
     "version": "13.0 beta 3",
     "build": "22A5295h",
-    "released": "2022-07-05",
+    "released": "2022-07-06",
     "beta": true,
     "deviceMap": [
         "Mac13,1",

--- a/iosFiles/macOS/22x - 13.x/22A5295h.json
+++ b/iosFiles/macOS/22x - 13.x/22A5295h.json
@@ -49,5 +49,43 @@
         "iMac20,1",
         "iMac20,2",
         "iMacPro1,1"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "Mac13,1",
+                "Mac13,2",
+                "Mac14,2",
+                "Mac14,7",
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "iMac21,1",
+                "iMac21,2",
+                "VirtualMac2,1"
+            ],
+            "type": "ipsw",
+            "size": 12109750298,
+            "hashes": {
+                "sha1": "e262fc71818b883890bb3c7b87c40dd59c9d8906",
+                "sha2-256": "2db34760f54a54aa705d49aa6489d0d4dafd81a6278b820a8de96fce997bd8b2"
+            },
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-34274/130176F5-C4CB-4664-A2F0-F29CA1281694/UniversalMac_13.0_22A5295h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-34274/130176F5-C4CB-4664-A2F0-F29CA1281694/UniversalMac_13.0_22A5295h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ]
+        }
     ]
 }


### PR DESCRIPTION
Add the ipsw source for macOS 13.0 beta 3, including file size and hashes. Also fix its release date (was July 5 and should be July 6).

(You should merge this by rebasing instead of  causing a useless merge commit :P)