### PR TITLE
yalu102/QuickPwn/openpwnage stuff

### DIFF
--- a/jailbreakFiles/legacy/openpwnage.js
+++ b/jailbreakFiles/legacy/openpwnage.js
@@ -19,12 +19,11 @@ module.exports = {
         pkgman: "cydia",
       }
     ],
-    latestVer: "Beta Build 8",
+    latestVer: "Beta Build 9",
     color: "#faf4f7",
     jailbreaksmeapp: true,
     type: "Semi-untethered",
-    firmwares: ["8.4b4","9.3.6"],
-    notes: "Substrate only works on iOS 9"
+    firmwares: ["8.4b4","9.3.6"]
   },
   compatibility: [
     {

--- a/jailbreakFiles/legacy/quickpwn.js
+++ b/jailbreakFiles/legacy/quickpwn.js
@@ -26,6 +26,7 @@ module.exports = {
       ],
       devices: [
         "iPhone1,1", // iPhone
+        "iPhone1,2", // iPhone 3G
         "iPod1,1", // iPod touch
         "iPod2,1", // iPod touch (2nd generation)
       ]

--- a/jailbreakFiles/legacy/yalu.js
+++ b/jailbreakFiles/legacy/yalu.js
@@ -60,7 +60,6 @@ module.exports = {
         "14B72c", // 10.1, iPhone 7 and iPhone 7 Plus only
         "14B100", // 10.1.1
         "14B150", // 10.1.1
-        "14C92", // 10.2
       ],
       devices: [
         "iPhone9,1", // iPhone 7 (Global), A10


### PR DESCRIPTION
While I still can't find anything regarding iPod Touch 2 and QuickPwn, it definitely *did* support iPhone 3G so I added it. Yalu102 doesn't work on 10.2 on devices with KTRR. Updated openpwnage to build 9.