### PR TITLE
Multiple fixes to macOS 12 data

### DIFF
--- a/iosFiles/macOS/21x - 12.x/21G5056b.json
+++ b/iosFiles/macOS/21x - 12.x/21G5056b.json
@@ -2,7 +2,7 @@
     "osStr": "macOS",
     "version": "12.5 beta 4",
     "build": "21G5056b",
-    "released": "2022-06-22",
+    "released": "2022-06-24",
     "beta": true,
     "deviceMap": [
         "Mac13,1",

--- a/iosFiles/macOS/21x - 12.x/21G5063a.json
+++ b/iosFiles/macOS/21x - 12.x/21G5063a.json
@@ -85,21 +85,21 @@
             "type": "ipsw",
             "links": [
                 {
-                    "url": "https://updates.cdn-apple.com/2022FallSeed/fullrestores/012-26441/AE0AC638-2773-49D3-BF84-950B10BF39E9/UniversalMac_12.5_21G5056b_Restore.ipsw",
+                    "url": "https://updates.cdn-apple.com/2022FallSeed/fullrestores/012-36748/52342C55-6598-4A86-AAB8-8901145792C8/UniversalMac_12.5_21G5063a_Restore.ipsw",
                     "preferred": true,
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022FallSeed/fullrestores/012-26441/AE0AC638-2773-49D3-BF84-950B10BF39E9/UniversalMac_12.5_21G5056b_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022FallSeed/fullrestores/012-36748/52342C55-6598-4A86-AAB8-8901145792C8/UniversalMac_12.5_21G5063a_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
             ],
             "hashes": {
-                "sha2-256": "a6c8f8d610ed5af8bd800b0a3e37287c89afc3859014a13d18c7959f3bbd544b",
-                "sha1": "9c05d3bfee69ad87b4f16225965990764bffebea"
+                "sha2-256": "01fa110b454ff769a7ffde85ae036622a11209692907ec601497405ceacf9561",
+                "sha1": "91865e546cc9482e0b1b502bd3d646c289121c22"
             },
-            "size": 13934172302
+            "size": 13938297123
         }
     ]
 }

--- a/iosFiles/macOS/21x - 12.x/21G72-RC.json
+++ b/iosFiles/macOS/21x - 12.x/21G72-RC.json
@@ -64,5 +64,43 @@
         "iMac20,1",
         "iMac20,2",
         "iMacPro1,1"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "Mac13,1",
+                "Mac13,2",
+                "Mac14,2",
+                "Mac14,7",
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "size": 14084058716,
+            "hashes": {
+                "sha1": "c61f6d5411a5ce703fde89c07d6a963863e4cf67",
+                "sha2-256": "49eb74f3313b0b0c22d4c055f56722143fdae1e5ccb1dcbf779a1a4c4dcbc42b"
+            },
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-42731/BD9917E0-262C-41C5-A69F-AC316A534A39/UniversalMac_12.5_21G72_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-42731/BD9917E0-262C-41C5-A69F-AC316A534A39/UniversalMac_12.5_21G72_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ]
+        }
     ]
 }

--- a/iosFiles/macOS/21x - 12.x/21G72.json
+++ b/iosFiles/macOS/21x - 12.x/21G72.json
@@ -3,6 +3,8 @@
     "version": "12.5",
     "build": "21G72",
     "released": "2022-07-20",
+    "release_notes": "https://support.apple.com/HT212585#macos125",
+    "security_notes": "https://support.apple.com/HT213345",
     "deviceMap": [
         "Mac13,1",
         "Mac13,2",
@@ -62,5 +64,43 @@
         "iMac20,1",
         "iMac20,2",
         "iMacPro1,1"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "Mac13,1",
+                "Mac13,2",
+                "Mac14,2",
+                "Mac14,7",
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "size": 14084058716,
+            "hashes": {
+                "sha1": "c61f6d5411a5ce703fde89c07d6a963863e4cf67",
+                "sha2-256": "49eb74f3313b0b0c22d4c055f56722143fdae1e5ccb1dcbf779a1a4c4dcbc42b"
+            },
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-42731/BD9917E0-262C-41C5-A69F-AC316A534A39/UniversalMac_12.5_21G72_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-42731/BD9917E0-262C-41C5-A69F-AC316A534A39/UniversalMac_12.5_21G72_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ]
+        }
     ]
 }


### PR DESCRIPTION
- Fix release date of macOS 12.5 beta 4
- Fix ipsw of macOS 12.5 beta 5 (it was copy-pasted from beta 4)
- Add ipsw, release notes and security notes for macOS 12.5 RC and final

(I keep seeing useless merge commits, please rebase when accepting these changes >.>)