### PR TITLE
Add ipsws for today's beta4

### DIFF
--- a/iosFiles/iOS/20x - 16.x/20A5328h.json
+++ b/iosFiles/iOS/20x - 16.x/20A5328h.json
@@ -28,5 +28,382 @@
         "iPhone14,4",
         "iPhone14,5",
         "iPhone14,6"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "iPhone10,1",
+                "iPhone10,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-45026/A01F2224-060E-42E8-8F1B-E6323A5BEFB7/iPhone_4.7_P3_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-45026/A01F2224-060E-42E8-8F1B-E6323A5BEFB7/iPhone_4.7_P3_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5762953002,
+            "hashes": {
+                "sha1": "20e8d56ea0cbad3862686ff7381c216c0c0e4504",
+                "sha2-256": "2bd04158d16da0bb8e4d604378f839aa426eb73eac8d1e4dc358995a4af1bf61"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone10,2",
+                "iPhone10,5"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44968/AF221270-6177-4FB5-A527-A8565943D97D/iPhone_5.5_P3_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44968/AF221270-6177-4FB5-A527-A8565943D97D/iPhone_5.5_P3_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5876542011,
+            "hashes": {
+                "sha1": "a6be8d2597d7d75de02cf74a457932b0062da771",
+                "sha2-256": "f7227b175ae4e85d2c8d9b6bf18d37ca856f15ba3ee1da6a21dc64f501970676"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone10,3",
+                "iPhone10,6"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44939/E2FEFA1C-1DCA-42D2-BE60-C53B06D40BB3/iPhone10,3,iPhone10,6_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44939/E2FEFA1C-1DCA-42D2-BE60-C53B06D40BB3/iPhone10,3,iPhone10,6_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5890303220,
+            "hashes": {
+                "sha1": "c5e0f030f21523da77ec6d4a0f5ede5b7574e38f",
+                "sha2-256": "1523be36e7f28c7d0cc1bc117d63c837e03573ac5ee39b44fc31d02acd76eee8"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone11,2",
+                "iPhone11,4",
+                "iPhone11,6"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-45031/C02282C2-A0C6-42DE-8501-8FD42E266BD9/iPhone11,2,iPhone11,4,iPhone11,6_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-45031/C02282C2-A0C6-42DE-8501-8FD42E266BD9/iPhone11,2,iPhone11,4,iPhone11,6_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6278372195,
+            "hashes": {
+                "sha1": "a4871cc3e8c3a6a06465921d374ddf80151fc56f",
+                "sha2-256": "954922869de38ba5dbb2b4a577c2ef54912efb990570f68ecb7e42dc259a945d"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone11,8"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44817/953A29B0-B5D2-4F77-879C-BCBBB5298B1E/iPhone11,8_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44817/953A29B0-B5D2-4F77-879C-BCBBB5298B1E/iPhone11,8_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6142028939,
+            "hashes": {
+                "sha1": "e65362926716dff73b996d99996e0938e7a2e6c2",
+                "sha2-256": "cc8b1ab468e4b59dc196df38f42d0b2d5cb998b24a22de6bf34f02136ba7d66c"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone12,1"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44842/58E98AC3-7867-4E85-B884-E4E327F235AB/iPhone12,1_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44842/58E98AC3-7867-4E85-B884-E4E327F235AB/iPhone12,1_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6068273595,
+            "hashes": {
+                "sha1": "6091eb74e7ccb9e0463cf4d3674d07cb50e18beb",
+                "sha2-256": "79c854d06f8b6eb0a106c5ec3c8745af4fcc8eabf626b2efc82aa3048477fc94"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone12,3",
+                "iPhone12,5"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-45052/B6F48BC3-29F7-466A-9576-6E9E59AA046D/iPhone12,3,iPhone12,5_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-45052/B6F48BC3-29F7-466A-9576-6E9E59AA046D/iPhone12,3,iPhone12,5_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6189954943,
+            "hashes": {
+                "sha1": "6d8d819f01aeb03ef5d947abd090ada93ffb5d3a",
+                "sha2-256": "7230b64873e7874160f1403fed72b5e478974b90270feedfaffeac6d1ce2540a"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone12,8"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44941/47B5A71A-93CD-4D85-9C09-7D6308E36DE1/iPhone12,8_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44941/47B5A71A-93CD-4D85-9C09-7D6308E36DE1/iPhone12,8_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6032973788,
+            "hashes": {
+                "sha1": "2cac8b50bc395049ea146c725d9c4dd9e3b5a821",
+                "sha2-256": "2e1ec234736e29595e89fc7a7d3d1ddd972314aa00424c0ed1efc3de56c5a2a1"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone13,1"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44870/0B31EC0A-05E6-4756-B806-981F0C68A025/iPhone13,1_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44870/0B31EC0A-05E6-4756-B806-981F0C68A025/iPhone13,1_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6299401412,
+            "hashes": {
+                "sha1": "565418ca5bf0bdb762e7535ce00debe925c54a86",
+                "sha2-256": "d47c7402ac0ac3f5302505e4c4d15c07723acab0aa88e665c6322bc5c71c2ad3"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone13,2",
+                "iPhone13,3"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-45061/367399E2-1B68-405E-AD9B-F60134AFD5FC/iPhone13,2,iPhone13,3_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-45061/367399E2-1B68-405E-AD9B-F60134AFD5FC/iPhone13,2,iPhone13,3_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6470780883,
+            "hashes": {
+                "sha1": "08b96df752548c899b91b30fa46cc31b62d4ebf4",
+                "sha2-256": "93d9a7ed55df0ac19338cf953c8cb44199567117243cdc841cf50fbd9cfce967"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone13,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44994/777A0C19-C8BA-4446-80B4-A1975B2CC5AC/iPhone13,4_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44994/777A0C19-C8BA-4446-80B4-A1975B2CC5AC/iPhone13,4_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6424417284,
+            "hashes": {
+                "sha1": "2aa1888c01873b48d7c6366783899c185b001e80",
+                "sha2-256": "f09d9586c5cccd2553a592e3b1a1f7fcfacd92e93923f975a6526c23ba4af843"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone14,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44946/B7460AEA-7A67-4F27-9D67-68958B5633C9/iPhone14,2_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44946/B7460AEA-7A67-4F27-9D67-68958B5633C9/iPhone14,2_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6465397302,
+            "hashes": {
+                "sha1": "9275937c0c2c0dcceffbbe4ee4cf83d5dc53d32a",
+                "sha2-256": "1f62d42d81ab48b3f4151922bb1b1b98c7138cb00efee41947c582870628f0da"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone14,3"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44896/70E13900-B4E5-4765-BC8C-FC049F0FE368/iPhone14,3_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44896/70E13900-B4E5-4765-BC8C-FC049F0FE368/iPhone14,3_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6465228226,
+            "hashes": {
+                "sha1": "5eda00215aa630d08a4f600bb32245632485fb82",
+                "sha2-256": "5ed3b41020f1ef1681aa67404d30218697e0a97ed525041799a6f8d0ce150aed"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone14,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44808/DD09F392-B87A-43C4-8AEE-D233074F4179/iPhone14,4_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44808/DD09F392-B87A-43C4-8AEE-D233074F4179/iPhone14,4_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6351430630,
+            "hashes": {
+                "sha1": "c9734751d3b3cbb69570d9cd1b0dbb5ca5a03e1c",
+                "sha2-256": "5bdb5ecb867b165416c670e45af44935db4c45b6ccb304f4b2b953e5ef23080e"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone14,5"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44935/3C1578DC-17C7-459A-8DA1-0A6DD5BB55A6/iPhone14,5_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44935/3C1578DC-17C7-459A-8DA1-0A6DD5BB55A6/iPhone14,5_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6347267146,
+            "hashes": {
+                "sha1": "00ed7d4cbc10580e91e2344be188b9ae27e9a507",
+                "sha2-256": "bfd397e695e213d6451df6e3480bffb1e5c455ef3a80b854d03f6cfe2b060ada"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone14,6"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-45030/C38C99D2-70D9-44FF-80F8-C79174BCFAB1/iPhone14,6_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-45030/C38C99D2-70D9-44FF-80F8-C79174BCFAB1/iPhone14,6_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6164628122,
+            "hashes": {
+                "sha1": "a416f732848b41317c0851f51820badff2a9cf0c",
+                "sha2-256": "51079a67f6493fbec8fa5dee5789aa1bf880e1947eb65c1a98cdaf4311389920"
+            }
+        }
     ]
 }

--- a/iosFiles/iPadOS/20x - 16.x/20A5328h.json
+++ b/iosFiles/iPadOS/20x - 16.x/20A5328h.json
@@ -50,6 +50,344 @@
         "iPad13,10",
         "iPad13,11",
         "iPad14,1",
-        "iPad14,2"
+        "iPad14,2",
+        "iPad13,16",
+        "iPad13,17"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "iPad7,11",
+                "iPad7,12"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-45025/8104FB60-DA19-4B46-B0DD-39511B997C4F/iPad_10.2_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-45025/8104FB60-DA19-4B46-B0DD-39511B997C4F/iPad_10.2_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5333724625,
+            "hashes": {
+                "sha1": "4e3c6f64435a8bd817b8f6d063e05f8e818d88ca",
+                "sha2-256": "4d11bddb922398f37aba015ad1da554b92ae769ca0eb58735be57aacdca865e8"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad11,6",
+                "iPad11,7"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44985/8C7CF508-5EE9-408F-A091-C5E83E7023CD/iPad_10.2_2020_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44985/8C7CF508-5EE9-408F-A091-C5E83E7023CD/iPad_10.2_2020_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5831039908,
+            "hashes": {
+                "sha1": "aee2b687153bdd43abcd9918d6fab8c81a870b4e",
+                "sha2-256": "2daafc967174a550408789fdebb5f2a957bf32f2a54f045a0bca86690c3d4506"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad12,1",
+                "iPad12,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-45048/D1FD72A3-4D2D-4B94-9D5F-EE7D3EB3343A/iPad_10.2_2021_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-45048/D1FD72A3-4D2D-4B94-9D5F-EE7D3EB3343A/iPad_10.2_2021_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5727357935,
+            "hashes": {
+                "sha1": "ef6b033e98c6a854fe890c8e6747d380aa4afa22",
+                "sha2-256": "f309c959b8d6fc7effe5c6d8e052e8d66a06a521fadc79946e8842d862439155"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad6,11",
+                "iPad6,12",
+                "iPad7,5",
+                "iPad7,6"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44824/645AF7EC-11F4-4436-A8BA-6DE040337C88/iPad_64bit_TouchID_ASTC_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44824/645AF7EC-11F4-4436-A8BA-6DE040337C88/iPad_64bit_TouchID_ASTC_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5457145076,
+            "hashes": {
+                "sha1": "e06ac90edd1b5f55a32b890e9c067b8fa4e3ad10",
+                "sha2-256": "9f4bd5504d6299ca1356cc5a478999a82ffa9d606ddc576d36fe809f31f166e0"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad13,1",
+                "iPad13,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44933/8D6E3B3F-7AA0-4698-817D-DC94BA5350B2/iPad_Fall_2020_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44933/8D6E3B3F-7AA0-4698-817D-DC94BA5350B2/iPad_Fall_2020_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5752351589,
+            "hashes": {
+                "sha1": "20a708955665290a6890171b44e21c57b6c1885f",
+                "sha2-256": "20e6f9c715a04dd727a32e04cc6db6d28eb029d692357eda0da0523518a876f2"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad14,1",
+                "iPad14,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44872/778C29CC-E6F5-419C-8998-47E5949ABDDC/iPad_Fall_2021_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44872/778C29CC-E6F5-419C-8998-47E5949ABDDC/iPad_Fall_2021_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5852705186,
+            "hashes": {
+                "sha1": "1251e7f19abbffa54a157c8556e24817664864ca",
+                "sha2-256": "866556f5f9ae23a6907c8637be9edbf1fadb0f2c9e1116740f372c0d9c020a01"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad6,7",
+                "iPad6,8"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-45032/4775D220-9B0E-4010-8B68-A01C5FB3FC47/iPadPro_12.9_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-45032/4775D220-9B0E-4010-8B68-A01C5FB3FC47/iPadPro_12.9_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5278313207,
+            "hashes": {
+                "sha1": "1bfb78960c1faae7c2905e56504844989f231a98",
+                "sha2-256": "bd37c276d53e76f561eb37452075a752c7e0b28cd71a51a447d689da923c17d2"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad6,3",
+                "iPad6,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44972/BECE0866-153D-4D93-8549-0423610DCFA5/iPadPro_9.7_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44972/BECE0866-153D-4D93-8549-0423610DCFA5/iPadPro_9.7_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5285922276,
+            "hashes": {
+                "sha1": "4a9d42449e71420e481b54cf7be6ae6f3722d9f7",
+                "sha2-256": "1ace8222d69f3505a598008a4bec7b88d8a6b077a1cd09aa72fc95ab648f522d"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad8,1",
+                "iPad8,10",
+                "iPad8,11",
+                "iPad8,12",
+                "iPad8,2",
+                "iPad8,3",
+                "iPad8,4",
+                "iPad8,5",
+                "iPad8,6",
+                "iPad8,7",
+                "iPad8,8",
+                "iPad8,9"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-45000/9C3D6A55-CAFC-479A-A07B-D4CE32C714CE/iPad_Pro_A12X_A12Z_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-45000/9C3D6A55-CAFC-479A-A07B-D4CE32C714CE/iPad_Pro_A12X_A12Z_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6154217650,
+            "hashes": {
+                "sha1": "b0ca5d17c8e68ccc1b5b2491cf9c0665118949e4",
+                "sha2-256": "c896274c18e9c3ecf887e930e7c83796cd1f87b48cdcf3561c8f6ce311a868ee"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad7,1",
+                "iPad7,2",
+                "iPad7,3",
+                "iPad7,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44966/B1D43E45-F1F7-4A4F-8BB2-1DFBA9470EBA/iPad_Pro_HFR_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44966/B1D43E45-F1F7-4A4F-8BB2-1DFBA9470EBA/iPad_Pro_HFR_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5330889096,
+            "hashes": {
+                "sha1": "49e7bb967f15fe3fd10f863ca87cc38ad2b94144",
+                "sha2-256": "9bd6eac673c80071eaeee8718a61bf8b02d461615aafe45cf28b3cf7cfcc0881"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad13,10",
+                "iPad13,11",
+                "iPad13,4",
+                "iPad13,5",
+                "iPad13,6",
+                "iPad13,7",
+                "iPad13,8",
+                "iPad13,9"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44954/5D30E761-D1DD-4E00-83FD-EA9C96ADD48E/iPad_Pro_Spring_2021_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44954/5D30E761-D1DD-4E00-83FD-EA9C96ADD48E/iPad_Pro_Spring_2021_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6000072138,
+            "hashes": {
+                "sha1": "2e91a5188ea99dabc5a67db4a5d6627f6fa125bb",
+                "sha2-256": "bc1bbfbe048f94056d231efbf14f506000a13fb63f39d28d32ed482b47b92311"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad11,1",
+                "iPad11,2",
+                "iPad11,3",
+                "iPad11,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-45008/0DD5A64B-FA85-4DD0-A51C-9E82FE983F28/iPad_Spring_2019_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-45008/0DD5A64B-FA85-4DD0-A51C-9E82FE983F28/iPad_Spring_2019_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5870476882,
+            "hashes": {
+                "sha1": "a72130ca8d16fa1dc62b870bce73e02d48850d41",
+                "sha2-256": "0b2efb41bbf698dc1b7a4958c4e46a090b2e722bea78495c9132f8d68b6299f7"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad13,16",
+                "iPad13,17"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-44978/63C30722-056E-4C1F-8357-88DC938D8258/iPad_Spring_2022_16.0_20A5328h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-44978/63C30722-056E-4C1F-8357-88DC938D8258/iPad_Spring_2022_16.0_20A5328h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5860240367,
+            "hashes": {
+                "sha1": "4d6c9a3966a3e5b2df9d3789476c4cdb25d2ddc9",
+                "sha2-256": "a6864d5eed5edafa0733daa15e2c6d81d14e0c6e0b174fef03e86b11f246cb58"
+            }
+        }
     ]
 }

--- a/iosFiles/macOS/22x - 13.x/22A5311f.json
+++ b/iosFiles/macOS/22x - 13.x/22A5311f.json
@@ -49,5 +49,43 @@
         "iMac20,1",
         "iMac20,2",
         "iMacPro1,1"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "Mac13,1",
+                "Mac13,2",
+                "Mac14,2",
+                "Mac14,7",
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-43316/6CE4D83A-E44C-4DD1-B47F-DE168355662E/UniversalMac_13.0_22A5311f_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-43316/6CE4D83A-E44C-4DD1-B47F-DE168355662E/UniversalMac_13.0_22A5311f_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 12177142220,
+            "hashes": {
+                "sha1": "23674707c41a87a85a825c5e166c035ef828f3fe",
+                "sha2-256": "29c111e79e8c2e8126f6bc3466e0b750a6a34968cc172caef9c44611ada023c8"
+            }
+        }
     ]
 }

--- a/iosFiles/tvOS/20x - 16.x/20J5344f.json
+++ b/iosFiles/tvOS/20x - 16.x/20J5344f.json
@@ -8,5 +8,30 @@
         "AppleTV5,3",
         "AppleTV6,2",
         "AppleTV11,1"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "AppleTV5,3"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-43815/14244770-9B25-4187-8DE9-295325A03349/AppleTV5,3_16.0_20J5344f_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-43815/14244770-9B25-4187-8DE9-295325A03349/AppleTV5,3_16.0_20J5344f_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 3528162294,
+            "hashes": {
+                "sha1": "0718c7701bf0a3fb10e1c4443347f1424b92882e",
+                "sha2-256": "96fd9778ed224c98977a2c7cdf75d681e1ece93b486d7ba8619be814dde74c84"
+            }
+        }
     ]
 }


### PR DESCRIPTION
This also adds iPad13,16 and iPad13,17 to the iPadOS deviceMap; please
check if I screwed something up.