### PR TITLE
Add missing macOS 12.x betas

### DIFF
--- a/iosFiles/macOS/21x - 12.x/21A5248p.json
+++ b/iosFiles/macOS/21x - 12.x/21A5248p.json
@@ -1,0 +1,15 @@
+{
+    "osStr": "macOS",
+    "version": "12.0 beta",
+    "build": "21A5248p",
+    "released": "2021-06-07",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21A5268h.json
+++ b/iosFiles/macOS/21x - 12.x/21A5268h.json
@@ -1,0 +1,41 @@
+{
+    "osStr": "macOS",
+    "version": "12.0 beta 2",
+    "build": "21A5268h",
+    "released": "2021-06-28",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2021SummerSeed/fullrestores/071-59958/FDF11DDC-77EE-4E34-AFF1-20118CBC350F/UniversalMac_12.0_21A5268h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2021SummerSeed/fullrestores/071-59958/FDF11DDC-77EE-4E34-AFF1-20118CBC350F/UniversalMac_12.0_21A5268h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 13730967354
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21A5284e.json
+++ b/iosFiles/macOS/21x - 12.x/21A5284e.json
@@ -1,0 +1,44 @@
+{
+    "osStr": "macOS",
+    "version": "12.0 beta 3",
+    "build": "21A5284e",
+    "released": "2021-07-14",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2021SummerSeed/fullrestores/071-63742/90636AD6-5E0A-4474-B652-A6A5AF4995E2/UniversalMac_12.0_21A5284e_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2021SummerSeed/fullrestores/071-63742/90636AD6-5E0A-4474-B652-A6A5AF4995E2/UniversalMac_12.0_21A5284e_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 13740320874,
+            "hashes": {
+                "sha2-256": "7bc99d69508cd4c534a8918f8ccc86a1bd7d773fc135d557680ffe6f21c07337"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21A5294g.json
+++ b/iosFiles/macOS/21x - 12.x/21A5294g.json
@@ -1,0 +1,45 @@
+{
+    "osStr": "macOS",
+    "version": "12.0 beta 4",
+    "build": "21A5294g",
+    "released": "2021-07-27",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2021SummerSeed/fullrestores/071-76100/A4B0FF60-8A75-4743-9D1D-E6DCE733225E/UniversalMac_12.0_21A5294g_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2021SummerSeed/fullrestores/071-76100/A4B0FF60-8A75-4743-9D1D-E6DCE733225E/UniversalMac_12.0_21A5294g_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 13776379854,
+            "hashes": {
+                "sha1": "d6bf5a24debe8264bed2f15ef67693077dc268f8",
+                "sha2-256": "5e64ffae3572bad12243a3f9482bf609c8e47dc3563c5d20a8c0c9231513945d"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21A5304g.json
+++ b/iosFiles/macOS/21x - 12.x/21A5304g.json
@@ -1,0 +1,45 @@
+{
+    "osStr": "macOS",
+    "version": "12.0 beta 5",
+    "build": "21A5304g",
+    "released": "2021-08-11",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2021SummerSeed/fullrestores/071-80097/9F639C04-F128-4EC9-93D3-2AAE04F8A314/UniversalMac_12.0_21A5304g_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2021SummerSeed/fullrestores/071-80097/9F639C04-F128-4EC9-93D3-2AAE04F8A314/UniversalMac_12.0_21A5304g_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 13782157739,
+            "hashes": {
+                "sha1": "b92b43ba322dab69e7d37ccc2cbe5936a9c0b51c",
+                "sha2-256": "45e56d649aa864d29d3a39da71c397981ce9306b37bfc4085170bd5990a7f742"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21A5506j.json
+++ b/iosFiles/macOS/21x - 12.x/21A5506j.json
@@ -1,0 +1,45 @@
+{
+    "osStr": "macOS",
+    "version": "12.0 beta 6",
+    "build": "21A5506j",
+    "released": "2021-08-30",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2021SummerSeed/fullrestores/071-91006/8BA901D3-6F15-4DC6-A9E1-C3537341C519/UniversalMac_12.0_21A5506j_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2021SummerSeed/fullrestores/071-91006/8BA901D3-6F15-4DC6-A9E1-C3537341C519/UniversalMac_12.0_21A5506j_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 13790327308,
+            "hashes": {
+                "sha1": "d578f6a1a0ebad47cc77bc811c8e94fba0277e04",
+                "sha2-256": "e46de11efed74b44ee7a93aaf8e4c7819ad9c54e70ee8a562e75c95cfb08175c"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21A5522h.json
+++ b/iosFiles/macOS/21x - 12.x/21A5522h.json
@@ -1,0 +1,45 @@
+{
+    "osStr": "macOS",
+    "version": "12.0 beta 7",
+    "build": "21A5522h",
+    "released": "2021-09-21",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2021SummerSeed/fullrestores/002-02558/9EEDAAF0-A559-4212-922E-C2620045A6CE/UniversalMac_12.0_21A5522h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2021SummerSeed/fullrestores/002-02558/9EEDAAF0-A559-4212-922E-C2620045A6CE/UniversalMac_12.0_21A5522h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 13724417516,
+            "hashes": {
+                "sha1": "d1a3e925e7ecdcd934f1d1bf0c0f843f76004e73",
+                "sha2-256": "86a001e85a4a531a0c07995bc49d150a310d132fa2ece6abaf2b8ca4a9df2d4a"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21A5534d.json
+++ b/iosFiles/macOS/21x - 12.x/21A5534d.json
@@ -1,0 +1,45 @@
+{
+    "osStr": "macOS",
+    "version": "12.0 beta 8",
+    "build": "21A5534d",
+    "released": "2021-09-28",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2021SummerSeed/fullrestores/002-03830/B8D1658D-A579-4479-BBB1-7CDEAF328303/UniversalMac_12.0_21A5534d_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2021SummerSeed/fullrestores/002-03830/B8D1658D-A579-4479-BBB1-7CDEAF328303/UniversalMac_12.0_21A5534d_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 13733651814,
+            "hashes": {
+                "sha1": "451768902ab1e3dddd57b1c1bd3df95016acdbbf",
+                "sha2-256": "9747475109d4ef30c05e5c416d8fdef7a35c40b1b81e1c50a9c73fc250b0dfa8"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21A5543b.json
+++ b/iosFiles/macOS/21x - 12.x/21A5543b.json
@@ -1,0 +1,45 @@
+{
+    "osStr": "macOS",
+    "version": "12.0 beta 9",
+    "build": "21A5543b",
+    "released": "2021-10-06",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2021SummerSeed/fullrestores/002-12797/682E85F3-78D2-4425-8774-C0950CD5EB8E/UniversalMac_12.0_21A5543b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2021SummerSeed/fullrestores/002-12797/682E85F3-78D2-4425-8774-C0950CD5EB8E/UniversalMac_12.0_21A5543b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 13793575502,
+            "hashes": {
+                "sha1": "fed84729223ad00faf1aeaeda26305559fdbe728",
+                "sha2-256": "a6ca0268e5ddf65846e5d6a20cff982351984d58d5f955de9ac0d4847db04afe"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21A5552a.json
+++ b/iosFiles/macOS/21x - 12.x/21A5552a.json
@@ -1,0 +1,45 @@
+{
+    "osStr": "macOS",
+    "version": "12.0 beta 10",
+    "build": "21A5552a",
+    "released": "2021-10-13",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2021SummerSeed/fullrestores/002-17770/4A6911AE-3A4E-47BA-8104-1A3CF596E0C6/UniversalMac_12.0_21A5552a_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2021SummerSeed/fullrestores/002-17770/4A6911AE-3A4E-47BA-8104-1A3CF596E0C6/UniversalMac_12.0_21A5552a_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 13792383095,
+            "hashes": {
+                "sha1": "f394f509461c65284f88cf57932ad8950758c3e9",
+                "sha2-256": "1769321904d6191637b14bd69a67157bc5335c19a1e7ee5ce75bdc2012805c94"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21A558.json
+++ b/iosFiles/macOS/21x - 12.x/21A558.json
@@ -1,0 +1,53 @@
+{
+    "osStr": "macOS",
+    "version": "12.0.1 RC",
+    "build": "21A558",
+    "released": "2021-10-18",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2021FCSFall/fullrestores/071-78663/75110021-A2D3-44BB-B90F-3AC39F7A4F00/UniversalMac_12.0.1_21A558_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2021FCSFall/fullrestores/071-78663/75110021-A2D3-44BB-B90F-3AC39F7A4F00/UniversalMac_12.0.1_21A558_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 14102733145,
+            "hashes": {
+                "sha1": "08f3e6094775dda042cca76b89b2ce22f3446527",
+                "sha2-256": "e7719fff71657ae126db50c3d1cfcff3bfd8ca6a0d1a7794aab45c44249844c4"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21A559-RC.json
+++ b/iosFiles/macOS/21x - 12.x/21A559-RC.json
@@ -1,0 +1,99 @@
+{
+    "osStr": "macOS",
+    "version": "12.0.1 RC 2",
+    "build": "21A559",
+    "uniqueBuild": "21A559-RC",
+    "released": "2021-10-21",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "iMac21,1",
+        "iMac21,2",
+        "VirtualMac2,1",
+        
+        "MacPro6,1",
+        "MacPro7,1",
+        "MacPro7,1-Rack",
+        "MacBook9,1",
+        "MacBook10,1",
+        "MacBookAir8,1",
+        "MacBookAir8,2",
+        "MacBookAir9,1",
+        "MacBookPro11,4",
+        "MacBookPro11,5",
+        "MacBookPro12,1",
+        "MacBookPro13,1",
+        "MacBookPro13,2",
+        "MacBookPro13,3",
+        "MacBookPro14,1",
+        "MacBookPro14,2",
+        "MacBookPro14,3",
+        "MacBookPro15,1-2018",
+        "MacBookPro15,2-2018",
+        "MacBookPro15,3-2018",
+        "MacBookPro15,1-2019",
+        "MacBookPro15,2-2019",
+        "MacBookPro15,3-2019",
+        "MacBookPro15,4",
+        "MacBookPro16,1",
+        "MacBookPro16,2",
+        "MacBookPro16,3",
+        "MacBookPro16,4",
+        "Macmini7,1",
+        "Macmini8,1",
+        "iMac15,1-Mid-2015",
+        "iMac16,1",
+        "iMac16,2",
+        "iMac16,2-4K",
+        "iMac17,1",
+        "iMac18,1",
+        "iMac18,2",
+        "iMac18,3",
+        "iMac19,1",
+        "iMac19,2",
+        "iMac20,1",
+        "iMac20,2",
+        "iMacPro1,1"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "iMac21,1",
+                "iMac21,2",
+                "VirtualMac2,1"
+            ],
+            "type": "ipsw",
+            "size": 14102871779,
+            "hashes": {
+                "sha1": "aa422d3ef4a8a1a454e66db586fa71a940901943",
+                "sha2-256": "3b8fcc1b674542a944fbefb69d29858b0728b1a829d18fd3d3e958691bc693bf",
+                "sha2-512": "dcca7344d2a5ccb888bceaff3bad485549879de0a8e4decd4964ebf61daf25169469662ea014b47e0b3fa86caee18dee7cecb0391e281b9b2a2a9293a947217b"
+            },
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2021FCSFall/fullrestores/002-23780/D3417F21-41BD-4DDF-9135-FA5A129AF6AF/UniversalMac_12.0.1_21A559_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2021FCSFall/fullrestores/002-23780/D3417F21-41BD-4DDF-9135-FA5A129AF6AF/UniversalMac_12.0.1_21A559_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ]
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21C5021h.json
+++ b/iosFiles/macOS/21x - 12.x/21C5021h.json
@@ -1,0 +1,53 @@
+{
+    "osStr": "macOS",
+    "version": "12.1 beta",
+    "build": "21C5021h",
+    "released": "2021-10-28",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2021SummerSeed/fullrestores/002-28337/D8103166-0CC8-4BD5-8C3A-16FA94517341/UniversalMac_12.1_21C5021h_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2021SummerSeed/fullrestores/002-28337/D8103166-0CC8-4BD5-8C3A-16FA94517341/UniversalMac_12.1_21C5021h_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 14126238222,
+            "hashes": {
+                "sha1": "7c641891fe8f0a34cff9f5ce61a805d9f11e6a2c",
+                "sha2-256": "b86f22f6b9d0e44ffcecd80699b22917c860f558a91792d9acaac35f1a06b05a"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21C5031d.json
+++ b/iosFiles/macOS/21x - 12.x/21C5031d.json
@@ -1,0 +1,53 @@
+{
+    "osStr": "macOS",
+    "version": "12.1 beta 2",
+    "build": "21C5031d",
+    "released": "2021-11-09",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2021SummerSeed/fullrestores/002-30063/355B4EC9-E369-4A89-B5B2-13E10C27EE30/UniversalMac_12.1_21C5031d_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2021SummerSeed/fullrestores/002-30063/355B4EC9-E369-4A89-B5B2-13E10C27EE30/UniversalMac_12.1_21C5031d_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 14157411232,
+            "hashes": {
+                "sha1": "dce29eced08ef4678a32c549e90b17860db80a4a",
+                "sha2-256": "3077b61d54d1bbd48c8af201dcb801c6feb8adbae850167d363fef62a00a5d0e"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21C5039b.json
+++ b/iosFiles/macOS/21x - 12.x/21C5039b.json
@@ -1,0 +1,53 @@
+{
+    "osStr": "macOS",
+    "version": "12.1 beta 3",
+    "build": "21C5039b",
+    "released": "2021-11-16",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2021WinterSeed/fullrestores/002-32824/9FAC31E8-73F2-47A7-A17B-C531CB4D5C11/UniversalMac_12.1_21C5039b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2021WinterSeed/fullrestores/002-32824/9FAC31E8-73F2-47A7-A17B-C531CB4D5C11/UniversalMac_12.1_21C5039b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 14131073115,
+            "hashes": {
+                "sha1": "d0ac1b246aa60031164e881ec3d37984582e3dbd",
+                "sha2-256": "cd2050822b1c2ec1bb675b18624501a1a79dc499a4f3ffe64cf0b72f68a9c223"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21C5045a.json
+++ b/iosFiles/macOS/21x - 12.x/21C5045a.json
@@ -1,0 +1,53 @@
+{
+    "osStr": "macOS",
+    "version": "12.1 beta 4",
+    "build": "21C5045a",
+    "released": "2021-12-01",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2021WinterSeed/fullrestores/002-37375/E20F2DD1-EF2A-4209-AF27-3651555F2CAD/UniversalMac_12.1_21C5045a_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2021WinterSeed/fullrestores/002-37375/E20F2DD1-EF2A-4209-AF27-3651555F2CAD/UniversalMac_12.1_21C5045a_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 14132325770,
+            "hashes": {
+                "sha1": "1d85f0853c8dcbba3a3c23004eb703d6d81aeef6",
+                "sha2-256": "c35d4d90a2cb8ab12272dd9a5f5af6f592d77208ff43d648d3aabd1fd69fb717"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21C51.json
+++ b/iosFiles/macOS/21x - 12.x/21C51.json
@@ -1,0 +1,53 @@
+{
+    "osStr": "macOS",
+    "version": "12.1 RC",
+    "build": "21C51",
+    "released": "2021-12-07",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2021FCSWinter/fullrestores/071-93435/E79725F0-BB22-462E-B846-FAB30DA7D389/UniversalMac_12.1_21C51_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2021FCSWinter/fullrestores/071-93435/E79725F0-BB22-462E-B846-FAB30DA7D389/UniversalMac_12.1_21C51_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 14141308604,
+            "hashes": {
+                "sha1": "1aeea9a7642626750a07fd026eb8189d80903017",
+                "sha2-256": "cd180ee3b7676853f766c8f8b60a29ba8b1a5df450ab4aa1986e72563d7f3b4e"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21C52-RC.json
+++ b/iosFiles/macOS/21x - 12.x/21C52-RC.json
@@ -1,0 +1,99 @@
+{
+    "osStr": "macOS",
+    "version": "12.1 RC 2",
+    "build": "21C52",
+    "uniqueBuild": "21C52-RC",
+    "released": "2021-12-10",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "iMac21,1",
+        "iMac21,2",
+        "VirtualMac2,1",
+        
+        "MacPro6,1",
+        "MacPro7,1",
+        "MacPro7,1-Rack",
+        "MacBook9,1",
+        "MacBook10,1",
+        "MacBookAir8,1",
+        "MacBookAir8,2",
+        "MacBookAir9,1",
+        "MacBookPro11,4",
+        "MacBookPro11,5",
+        "MacBookPro12,1",
+        "MacBookPro13,1",
+        "MacBookPro13,2",
+        "MacBookPro13,3",
+        "MacBookPro14,1",
+        "MacBookPro14,2",
+        "MacBookPro14,3",
+        "MacBookPro15,1-2018",
+        "MacBookPro15,2-2018",
+        "MacBookPro15,3-2018",
+        "MacBookPro15,1-2019",
+        "MacBookPro15,2-2019",
+        "MacBookPro15,3-2019",
+        "MacBookPro15,4",
+        "MacBookPro16,1",
+        "MacBookPro16,2",
+        "MacBookPro16,3",
+        "MacBookPro16,4",
+        "Macmini7,1",
+        "Macmini8,1",
+        "iMac15,1-Mid-2015",
+        "iMac16,1",
+        "iMac16,2",
+        "iMac16,2-4K",
+        "iMac17,1",
+        "iMac18,1",
+        "iMac18,2",
+        "iMac18,3",
+        "iMac19,1",
+        "iMac19,2",
+        "iMac20,1",
+        "iMac20,2",
+        "iMacPro1,1"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "iMac21,1",
+                "iMac21,2",
+                "VirtualMac2,1"
+            ],
+            "type": "ipsw",
+            "size": 14141114913,
+            "hashes": {
+                "sha1": "04421498d4e6e031f2269c988a2663ebacb774e4",
+                "sha2-256": "8d3863cd4a09d5cfd75c4a3e61f7605d800f653b5ecd6e8628b19a44de6a67b0",
+                "sha2-512": "504027e596714bfd04b54dda99518e417c1e117c14ef66f39716f377587e484454d9f790e9ca5f1aa6728ecebe5768be0d141237fe8763b0fe7089e7ef7cdc6a"
+            },
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2021FCSWinter/fullrestores/002-42433/F3F6D5CD-67FE-449C-9212-F7409808B6C4/UniversalMac_12.1_21C52_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2021FCSWinter/fullrestores/002-42433/F3F6D5CD-67FE-449C-9212-F7409808B6C4/UniversalMac_12.1_21C52_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ]
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21D48.json
+++ b/iosFiles/macOS/21x - 12.x/21D48.json
@@ -1,0 +1,53 @@
+{
+    "osStr": "macOS",
+    "version": "12.2 RC",
+    "build": "21D48",
+    "released": "2022-01-20",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022WinterFCS/fullrestores/002-55683/C906700F-79F2-4948-98F0-E8A7D2FB129D/UniversalMac_12.2_21D48_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022WinterFCS/fullrestores/002-55683/C906700F-79F2-4948-98F0-E8A7D2FB129D/UniversalMac_12.2_21D48_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 14140394588,
+            "hashes": {
+                "sha1": "f2289771a69353d464ab5eeb230ec063f6d5f011",
+                "sha2-256": "a7116572f8f8d84c383c485d89c17c003fe6b509d33d1b463cfac86b27155f66"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21D5025f.json
+++ b/iosFiles/macOS/21x - 12.x/21D5025f.json
@@ -1,0 +1,53 @@
+{
+    "osStr": "macOS",
+    "version": "12.2 beta",
+    "build": "21D5025f",
+    "released": "2021-12-16",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022WinterSeed/fullrestores/002-44442/020A8396-9611-4BA6-9AF6-BEFE6434BEF6/UniversalMac_12.2_21D5025f_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022WinterSeed/fullrestores/002-44442/020A8396-9611-4BA6-9AF6-BEFE6434BEF6/UniversalMac_12.2_21D5025f_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 14147498215,
+            "hashes": {
+                "sha1": "c8679deb3b606bc80d7e82e02459b1f3ebddc433",
+                "sha2-256": "9aa937f7cd10f194be8c182680db2230ffe3685cb285be3db5d28ff8bb175105"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21D5039d.json
+++ b/iosFiles/macOS/21x - 12.x/21D5039d.json
@@ -1,0 +1,53 @@
+{
+    "osStr": "macOS",
+    "version": "12.2 beta 2",
+    "build": "21D5039d",
+    "released": "2022-01-11",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022WinterSeed/fullrestores/002-47658/700407BD-83F1-4453-BAB4-21CAAFD85EC8/UniversalMac_12.2_21D5039d_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022WinterSeed/fullrestores/002-47658/700407BD-83F1-4453-BAB4-21CAAFD85EC8/UniversalMac_12.2_21D5039d_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 14137501504,
+            "hashes": {
+                "sha1": "b410e58422336ef8c3948c4be79f562916ddcec5",
+                "sha2-256": "bb0aaa5d3abe9de10fb5a0c6dcf5430a7ec193de156cd0c19c03ef406da82300"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21E5196i.json
+++ b/iosFiles/macOS/21x - 12.x/21E5196i.json
@@ -1,0 +1,53 @@
+{
+    "osStr": "macOS",
+    "version": "12.3 beta",
+    "build": "21E5196i",
+    "released": "2022-01-27",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022WinterSeed/fullrestores/002-59521/A51A8FB8-F6C3-47E3-AC02-A370AAF53C57/UniversalMac_12.3_21E5196i_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022WinterSeed/fullrestores/002-59521/A51A8FB8-F6C3-47E3-AC02-A370AAF53C57/UniversalMac_12.3_21E5196i_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 13830742362,
+            "hashes": {
+                "sha1": "9ab2e2205899d31ad5791bdf038bc418eb5b931f",
+                "sha2-256": "0bee897e898af1c87a7565e8710f52f5655f8cfb99deefd2ce6b4b0f9e9245e0"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21E5206e.json
+++ b/iosFiles/macOS/21x - 12.x/21E5206e.json
@@ -1,0 +1,53 @@
+{
+    "osStr": "macOS",
+    "version": "12.3 beta 2",
+    "build": "21E5206e",
+    "released": "2022-02-08",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022WinterSeed/fullrestores/002-66214/648B34E5-A2D9-45A8-9191-0683F266109A/UniversalMac_12.3_21E5206e_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022WinterSeed/fullrestores/002-66214/648B34E5-A2D9-45A8-9191-0683F266109A/UniversalMac_12.3_21E5206e_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 13821463758,
+            "hashes": {
+                "sha1": "6f6022116b2faaeee6a808c4c170ee295f07adec",
+                "sha2-256": "27ed1bcf8be0e811707dd8deb2e5e99fdd81dc422d14ec861100408a7a77cc9c"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21E5212f.json
+++ b/iosFiles/macOS/21x - 12.x/21E5212f.json
@@ -1,0 +1,53 @@
+{
+    "osStr": "macOS",
+    "version": "12.3 beta 3",
+    "build": "21E5212f",
+    "released": "2022-02-15",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022WinterSeed/fullrestores/002-70004/8F82317F-9417-455E-BECE-75665E05245A/UniversalMac_12.3_21E5212f_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022WinterSeed/fullrestores/002-70004/8F82317F-9417-455E-BECE-75665E05245A/UniversalMac_12.3_21E5212f_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 13838625575,
+            "hashes": {
+                "sha1": "63c3d3bfe0fb576ada7d3f47e50e4a066dac1f1f",
+                "sha2-256": "c71edf4ce80448bee83fe7c300adf2827834d864248239b85ad0375d14093ab3"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21E5222a.json
+++ b/iosFiles/macOS/21x - 12.x/21E5222a.json
@@ -1,0 +1,53 @@
+{
+    "osStr": "macOS",
+    "version": "12.3 beta 4",
+    "build": "21E5222a",
+    "released": "2022-02-22",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022WinterSeed/fullrestores/002-71800/D7E4B25F-0975-46C0-9556-B46FAA4F3CD1/UniversalMac_12.3_21E5222a_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022WinterSeed/fullrestores/002-71800/D7E4B25F-0975-46C0-9556-B46FAA4F3CD1/UniversalMac_12.3_21E5222a_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 13811811375,
+            "hashes": {
+                "sha1": "200927ebab026c8761d05efaffed383153b4aa3c",
+                "sha2-256": "1841039d24d671e3faa187c4164cd645103cedd1b7c4567c16c2abe4d5ca42b9"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21E5227a.json
+++ b/iosFiles/macOS/21x - 12.x/21E5227a.json
@@ -1,0 +1,53 @@
+{
+    "osStr": "macOS",
+    "version": "12.3 beta 5",
+    "build": "21E5227a",
+    "released": "2022-03-01",
+    "beta": true,
+    "deviceMap": [
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022WinterSeed/fullrestores/002-74576/80405F19-AB4A-4979-B730-604E7E437732/UniversalMac_12.3_21E5227a_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022WinterSeed/fullrestores/002-74576/80405F19-AB4A-4979-B730-604E7E437732/UniversalMac_12.3_21E5227a_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 13814303508,
+            "hashes": {
+                "sha1": "5f87af4e293a5fa5b7d0bd23c6cabb8a3b20adc0",
+                "sha2-256": "c1fedc903dc8dbecd3f7407aec96d582b6c12d24ea0a78d31b49754cc0ad1a25"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21F5048e.json
+++ b/iosFiles/macOS/21x - 12.x/21F5048e.json
@@ -1,0 +1,57 @@
+{
+    "osStr": "macOS",
+    "version": "12.4 beta",
+    "build": "21F5048e",
+    "released": "2022-04-05",
+    "beta": true,
+    "deviceMap": [
+        "Mac13,1",
+        "Mac13,2",
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "VirtualMac2,1",
+        "iMac21,1",
+        "iMac21,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "Mac13,1",
+                "Mac13,2",
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SpringSeed/fullrestores/002-85721/A21FF659-8493-4A16-A989-2C3141F48D8C/UniversalMac_12.4_21F5048e_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/002-85721/A21FF659-8493-4A16-A989-2C3141F48D8C/UniversalMac_12.4_21F5048e_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 13812557221,
+            "hashes": {
+                "sha1": "5c47439ee9b1c1b809f822d47244e8ac41121887",
+                "sha2-256": "447ac5bb65ca89cda9183eb7acaa808abf71b5409862d892ea4c99809e6c84d0"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
The data matches theiphonewiki now.

Please review the RCs in particular; I'm not sure if what I did with uniqueBuild is correct.