### PR TITLE
Add missing Watch3,4 to deviceMap of several watchOS versions

### DIFF
--- a/iosFiles/watchOS/15x - 4.x/15R372.json
+++ b/iosFiles/watchOS/15x - 4.x/15R372.json
@@ -13,6 +13,7 @@
         "Watch2,7",
         "Watch3,1",
         "Watch3,2",
-        "Watch3,3"
+        "Watch3,3",
+        "Watch3,4"
     ]
 }

--- a/iosFiles/watchOS/15x - 4.x/15R654.json
+++ b/iosFiles/watchOS/15x - 4.x/15R654.json
@@ -13,6 +13,7 @@
         "Watch2,7",
         "Watch3,1",
         "Watch3,2",
-        "Watch3,3"
+        "Watch3,3",
+        "Watch3,4"
     ]
 }

--- a/iosFiles/watchOS/15x - 4.x/15R846.json
+++ b/iosFiles/watchOS/15x - 4.x/15R846.json
@@ -13,6 +13,7 @@
         "Watch2,7",
         "Watch3,1",
         "Watch3,2",
-        "Watch3,3"
+        "Watch3,3",
+        "Watch3,4"
     ]
 }

--- a/iosFiles/watchOS/15x - 4.x/15S102.json
+++ b/iosFiles/watchOS/15x - 4.x/15S102.json
@@ -13,6 +13,7 @@
         "Watch2,7",
         "Watch3,1",
         "Watch3,2",
-        "Watch3,3"
+        "Watch3,3",
+        "Watch3,4"
     ]
 }

--- a/iosFiles/watchOS/15x - 4.x/15S542.json
+++ b/iosFiles/watchOS/15x - 4.x/15S542.json
@@ -13,6 +13,7 @@
         "Watch2,7",
         "Watch3,1",
         "Watch3,2",
-        "Watch3,3"
+        "Watch3,3",
+        "Watch3,4"
     ]
 }

--- a/iosFiles/watchOS/15x - 4.x/15S600b.json
+++ b/iosFiles/watchOS/15x - 4.x/15S600b.json
@@ -13,6 +13,7 @@
         "Watch2,7",
         "Watch3,1",
         "Watch3,2",
-        "Watch3,3"
+        "Watch3,3",
+        "Watch3,4"
     ]
 }

--- a/iosFiles/watchOS/15x - 4.x/15T212.json
+++ b/iosFiles/watchOS/15x - 4.x/15T212.json
@@ -13,6 +13,7 @@
         "Watch2,7",
         "Watch3,1",
         "Watch3,2",
-        "Watch3,3"
+        "Watch3,3",
+        "Watch3,4"
     ]
 }

--- a/iosFiles/watchOS/15x - 4.x/15T567.json
+++ b/iosFiles/watchOS/15x - 4.x/15T567.json
@@ -13,6 +13,7 @@
         "Watch2,7",
         "Watch3,1",
         "Watch3,2",
-        "Watch3,3"
+        "Watch3,3",
+        "Watch3,4"
     ]
 }

--- a/iosFiles/watchOS/15x - 4.x/15U70.json
+++ b/iosFiles/watchOS/15x - 4.x/15U70.json
@@ -13,6 +13,7 @@
         "Watch2,7",
         "Watch3,1",
         "Watch3,2",
-        "Watch3,3"
+        "Watch3,3",
+        "Watch3,4"
     ]
 }

--- a/iosFiles/watchOS/16x - 5.x/16R364.json
+++ b/iosFiles/watchOS/16x - 5.x/16R364.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/16x - 5.x/16R381.json
+++ b/iosFiles/watchOS/16x - 5.x/16R381.json
@@ -11,6 +11,7 @@
         "Watch2,7",
         "Watch3,1",
         "Watch3,2",
-        "Watch3,3"
+        "Watch3,3",
+        "Watch3,4"
     ]
 }

--- a/iosFiles/watchOS/16x - 5.x/16R591.json
+++ b/iosFiles/watchOS/16x - 5.x/16R591.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/16x - 5.x/16R600.json
+++ b/iosFiles/watchOS/16x - 5.x/16R600.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/16x - 5.x/16S46.json
+++ b/iosFiles/watchOS/16x - 5.x/16S46.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/16x - 5.x/16S535.json
+++ b/iosFiles/watchOS/16x - 5.x/16S535.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/16x - 5.x/16T225.json
+++ b/iosFiles/watchOS/16x - 5.x/16T225.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/16x - 5.x/16U113.json
+++ b/iosFiles/watchOS/16x - 5.x/16U113.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/16x - 5.x/16U569.json
+++ b/iosFiles/watchOS/16x - 5.x/16U569.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/16x - 5.x/16U600.json
+++ b/iosFiles/watchOS/16x - 5.x/16U600.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/16x - 5.x/16U627.json
+++ b/iosFiles/watchOS/16x - 5.x/16U627.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/16x - 5.x/16U652.json
+++ b/iosFiles/watchOS/16x - 5.x/16U652.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/16x - 5.x/16U662.json
+++ b/iosFiles/watchOS/16x - 5.x/16U662.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/16x - 5.x/16U674.json
+++ b/iosFiles/watchOS/16x - 5.x/16U674.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/16x - 5.x/16U680.json
+++ b/iosFiles/watchOS/16x - 5.x/16U680.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/16x - 5.x/16U693.json
+++ b/iosFiles/watchOS/16x - 5.x/16U693.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/17x - 6.x/17R575.json
+++ b/iosFiles/watchOS/17x - 6.x/17R575.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/17x - 6.x/17R604.json
+++ b/iosFiles/watchOS/17x - 6.x/17R604.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch5,1",
         "Watch5,2",
         "Watch5,3",

--- a/iosFiles/watchOS/17x - 6.x/17S449.json
+++ b/iosFiles/watchOS/17x - 6.x/17S449.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/17x - 6.x/17S796.json
+++ b/iosFiles/watchOS/17x - 6.x/17S796.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/17x - 6.x/17S811.json
+++ b/iosFiles/watchOS/17x - 6.x/17S811.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/17x - 6.x/17S84.json
+++ b/iosFiles/watchOS/17x - 6.x/17S84.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/17x - 6.x/17T529.json
+++ b/iosFiles/watchOS/17x - 6.x/17T529.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/17x - 6.x/17T530.json
+++ b/iosFiles/watchOS/17x - 6.x/17T530.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/17x - 6.x/17T608.json
+++ b/iosFiles/watchOS/17x - 6.x/17T608.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/17x - 6.x/17T620.json
+++ b/iosFiles/watchOS/17x - 6.x/17T620.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/17x - 6.x/17U203.json
+++ b/iosFiles/watchOS/17x - 6.x/17U203.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/17x - 6.x/17U208.json
+++ b/iosFiles/watchOS/17x - 6.x/17U208.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/17x - 6.x/17U63.json
+++ b/iosFiles/watchOS/17x - 6.x/17U63.json
@@ -12,6 +12,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/18x - 7.x/18R382.json
+++ b/iosFiles/watchOS/18x - 7.x/18R382.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/18x - 7.x/18R395.json
+++ b/iosFiles/watchOS/18x - 7.x/18R395.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/18x - 7.x/18R402.json
+++ b/iosFiles/watchOS/18x - 7.x/18R402.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/18x - 7.x/18R410.json
+++ b/iosFiles/watchOS/18x - 7.x/18R410.json
@@ -7,6 +7,7 @@
     "deviceMap": [
         "Watch3,1",
         "Watch3,2",
-        "Watch3,3"
+        "Watch3,3",
+        "Watch3,4"
     ]
 }

--- a/iosFiles/watchOS/18x - 7.x/18R590.json
+++ b/iosFiles/watchOS/18x - 7.x/18R590.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/18x - 7.x/18S564.json
+++ b/iosFiles/watchOS/18x - 7.x/18S564.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/18x - 7.x/18S801.json
+++ b/iosFiles/watchOS/18x - 7.x/18S801.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/18x - 7.x/18S811.json
+++ b/iosFiles/watchOS/18x - 7.x/18S811.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/18x - 7.x/18S821.json
+++ b/iosFiles/watchOS/18x - 7.x/18S821.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/18x - 7.x/18S830.json
+++ b/iosFiles/watchOS/18x - 7.x/18S830.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/18x - 7.x/18T195.json
+++ b/iosFiles/watchOS/18x - 7.x/18T195.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/18x - 7.x/18T201.json
+++ b/iosFiles/watchOS/18x - 7.x/18T201.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/18x - 7.x/18T567.json
+++ b/iosFiles/watchOS/18x - 7.x/18T567.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/18x - 7.x/18U63.json
+++ b/iosFiles/watchOS/18x - 7.x/18U63.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/18x - 7.x/18U70.json
+++ b/iosFiles/watchOS/18x - 7.x/18U70.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/18x - 7.x/18U80.json
+++ b/iosFiles/watchOS/18x - 7.x/18U80.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/19x - 8.x/19R346.json
+++ b/iosFiles/watchOS/19x - 8.x/19R346.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/19x - 8.x/19R354.json
+++ b/iosFiles/watchOS/19x - 8.x/19R354.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/19x - 8.x/19R570.json
+++ b/iosFiles/watchOS/19x - 8.x/19R570.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/19x - 8.x/19S546.json
+++ b/iosFiles/watchOS/19x - 8.x/19S546.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/19x - 8.x/19S55.json
+++ b/iosFiles/watchOS/19x - 8.x/19S55.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",

--- a/iosFiles/watchOS/19x - 8.x/19S553.json
+++ b/iosFiles/watchOS/19x - 8.x/19S553.json
@@ -8,6 +8,7 @@
         "Watch3,1",
         "Watch3,2",
         "Watch3,3",
+        "Watch3,4",
         "Watch4,1",
         "Watch4,2",
         "Watch4,3",


### PR DESCRIPTION
I added Watch3,4 to all files that already had Watch3,3. Any idea why they were missing to begin with...?