### PR TITLE
Fix iPadOS ipsw URLs

### DIFF
--- a/iosFiles/iPadOS/19x - 15.x/19G69.json
+++ b/iosFiles/iPadOS/19x - 15.x/19G69.json
@@ -72,7 +72,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-40411/B7A81337-70CD-4A34-9B8E-2DDF689FCD05/iPad_64bit_TouchID_15.6_19G69_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-40411/B7A81337-70CD-4A34-9B8E-2DDF689FCD05/iPad_64bit_TouchID_15.6_19G69_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -91,7 +91,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-40424/3E3BD66D-9773-44F1-A4D1-8B8C4657B5A4/iPadPro_9.7_15.6_19G69_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-40424/3E3BD66D-9773-44F1-A4D1-8B8C4657B5A4/iPadPro_9.7_15.6_19G69_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -110,7 +110,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-40455/C6B642CE-B8A5-409C-9B9B-93B621EF6C65/iPadPro_12.9_15.6_19G69_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-40455/C6B642CE-B8A5-409C-9B9B-93B621EF6C65/iPadPro_12.9_15.6_19G69_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -131,7 +131,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-40442/06DAE56B-7E3E-48FF-8446-F245037C25B0/iPad_64bit_TouchID_ASTC_15.6_19G69_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-40442/06DAE56B-7E3E-48FF-8446-F245037C25B0/iPad_64bit_TouchID_ASTC_15.6_19G69_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -152,7 +152,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-40404/9D91A6AA-7883-4293-BF3F-A6A0EDD4DA3C/iPad_Pro_HFR_15.6_19G69_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-40404/9D91A6AA-7883-4293-BF3F-A6A0EDD4DA3C/iPad_Pro_HFR_15.6_19G69_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -171,7 +171,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-40407/210092EB-DE58-4E3A-BB08-3C4261F761CC/iPad_10.2_15.6_19G69_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-40407/210092EB-DE58-4E3A-BB08-3C4261F761CC/iPad_10.2_15.6_19G69_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -200,7 +200,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-40471/CB56EA12-A410-4DDF-A930-720CF079DBFD/iPad_Pro_A12X_A12Z_15.6_19G69_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-40471/CB56EA12-A410-4DDF-A930-720CF079DBFD/iPad_Pro_A12X_A12Z_15.6_19G69_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -216,12 +216,12 @@
             "type": "ipsw",
             "links": [
                 {
-                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-41746/08592532-6B16-4483-8D22-4C671EE10AD6/iPad_Spring_2019_15.6_19G71_Restore.ipsw",
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-40482/4E95C18A-CD08-42C6-8FF8-7B47841BBF59/iPad_Spring_2019_15.6_19G69_Restore.ipsw",
                     "preferred": true,
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-41746/08592532-6B16-4483-8D22-4C671EE10AD6/iPad_Spring_2019_15.6_19G71_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-40482/4E95C18A-CD08-42C6-8FF8-7B47841BBF59/iPad_Spring_2019_15.6_19G69_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -240,7 +240,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-40428/676C130D-40AA-4797-9698-BD871AED153D/iPad_10.2_2020_15.6_19G69_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-40428/676C130D-40AA-4797-9698-BD871AED153D/iPad_10.2_2020_15.6_19G69_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -259,7 +259,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-40465/68F0E70B-ECD1-4E50-8563-FF83BF559678/iPad_10.2_2021_15.6_19G69_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-40465/68F0E70B-ECD1-4E50-8563-FF83BF559678/iPad_10.2_2021_15.6_19G69_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -278,7 +278,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-40447/BC4B2EB1-F9F8-47A2-B976-A93233965403/iPad_Fall_2020_15.6_19G69_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-40447/BC4B2EB1-F9F8-47A2-B976-A93233965403/iPad_Fall_2020_15.6_19G69_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -303,7 +303,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-40449/01F36581-AE42-456D-888A-1A3C0F8BD3A3/iPad_Pro_Spring_2021_15.6_19G69_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-40449/01F36581-AE42-456D-888A-1A3C0F8BD3A3/iPad_Pro_Spring_2021_15.6_19G69_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -322,7 +322,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-40425/09E506E2-F200-4744-ADF6-BB7290216AA5/iPad_Spring_2022_15.6_19G69_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-40425/09E506E2-F200-4744-ADF6-BB7290216AA5/iPad_Spring_2022_15.6_19G69_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -341,7 +341,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-40429/72F7DD9E-51B0-4FCB-A230-A8C4A6907701/iPad_Fall_2021_15.6_19G69_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-40429/72F7DD9E-51B0-4FCB-A230-A8C4A6907701/iPad_Fall_2021_15.6_19G69_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }

--- a/iosFiles/iPadOS/19x - 15.x/19G71.json
+++ b/iosFiles/iPadOS/19x - 15.x/19G71.json
@@ -78,7 +78,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-41685/A12D2F85-A629-49EF-B5F7-FDF71C040564/iPad_64bit_TouchID_15.6_19G71_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-41685/A12D2F85-A629-49EF-B5F7-FDF71C040564/iPad_64bit_TouchID_15.6_19G71_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -97,7 +97,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-41715/E4DA0FA6-62E3-4B50-969C-27687C21563E/iPadPro_9.7_15.6_19G71_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-41715/E4DA0FA6-62E3-4B50-969C-27687C21563E/iPadPro_9.7_15.6_19G71_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -116,7 +116,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-41712/F0D1482E-9375-4B8A-AACA-F9530911719E/iPadPro_12.9_15.6_19G71_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-41712/F0D1482E-9375-4B8A-AACA-F9530911719E/iPadPro_12.9_15.6_19G71_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -137,7 +137,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-41686/15A91AE0-AE2D-46FA-8731-5E5AC615D629/iPad_64bit_TouchID_ASTC_15.6_19G71_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-41686/15A91AE0-AE2D-46FA-8731-5E5AC615D629/iPad_64bit_TouchID_ASTC_15.6_19G71_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -158,7 +158,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-41747/A13B8FE1-EBCE-43B7-A168-BC6B10833FA0/iPad_Pro_HFR_15.6_19G71_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-41747/A13B8FE1-EBCE-43B7-A168-BC6B10833FA0/iPad_Pro_HFR_15.6_19G71_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -177,7 +177,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-41673/7EC5E837-D218-455A-930E-60E8ECE9D989/iPad_10.2_15.6_19G71_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-41673/7EC5E837-D218-455A-930E-60E8ECE9D989/iPad_10.2_15.6_19G71_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -206,7 +206,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-41713/3572F394-754F-4C7A-8432-6BBB2A716EDF/iPad_Pro_A12X_A12Z_15.6_19G71_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-41713/3572F394-754F-4C7A-8432-6BBB2A716EDF/iPad_Pro_A12X_A12Z_15.6_19G71_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -227,7 +227,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-41746/08592532-6B16-4483-8D22-4C671EE10AD6/iPad_Spring_2019_15.6_19G71_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-41746/08592532-6B16-4483-8D22-4C671EE10AD6/iPad_Spring_2019_15.6_19G71_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -246,7 +246,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-41756/437F886B-D623-4FC7-A558-47EC2CFB8D14/iPad_10.2_2020_15.6_19G71_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-41756/437F886B-D623-4FC7-A558-47EC2CFB8D14/iPad_10.2_2020_15.6_19G71_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -265,7 +265,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-41731/3B2BAB69-81DA-4B69-80E8-82AC76CCC8F4/iPad_10.2_2021_15.6_19G71_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-41731/3B2BAB69-81DA-4B69-80E8-82AC76CCC8F4/iPad_10.2_2021_15.6_19G71_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -284,7 +284,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-41738/01125072-4B7B-4FDF-8AD1-87866A0C8DE2/iPad_Fall_2020_15.6_19G71_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-41738/01125072-4B7B-4FDF-8AD1-87866A0C8DE2/iPad_Fall_2020_15.6_19G71_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -309,7 +309,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-41710/A7AFF049-FD8B-402F-AF3B-DB5767F2E40E/iPad_Pro_Spring_2021_15.6_19G71_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-41710/A7AFF049-FD8B-402F-AF3B-DB5767F2E40E/iPad_Pro_Spring_2021_15.6_19G71_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -328,7 +328,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-41758/FACD41CF-F317-4C04-8EBA-EC475FB14A15/iPad_Spring_2022_15.6_19G71_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-41758/FACD41CF-F317-4C04-8EBA-EC475FB14A15/iPad_Spring_2022_15.6_19G71_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }
@@ -347,7 +347,7 @@
                     "active": true
                 },
                 {
-                    "url": "http://updates-http.cdn-apple.com/2022SpringSeed/fullrestores/012-41755/903AA55F-ECC2-4839-8728-5D5F4BCC03C8/iPad_Fall_2021_15.6_19G71_Restore.ipsw",
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-41755/903AA55F-ECC2-4839-8728-5D5F4BCC03C8/iPad_Fall_2021_15.6_19G71_Restore.ipsw",
                     "preferred": false,
                     "active": true
                 }


### PR DESCRIPTION
They were added incorrectly in 93b00aaa, and only partially fixed in 3a3def38.