### PR TITLE
Add iOS/tvOS 16.0 beta 6

### DIFF
--- a/iosFiles/iOS/20x - 16.x/20A5349b.json
+++ b/iosFiles/iOS/20x - 16.x/20A5349b.json
@@ -1,0 +1,409 @@
+{
+    "osStr": "iOS",
+    "version": "16.0 beta 6",
+    "build": "20A5349b",
+    "released": "2022-08-15",
+    "beta": true,
+    "deviceMap": [
+        "iPhone10,1",
+        "iPhone10,2",
+        "iPhone10,3",
+        "iPhone10,4",
+        "iPhone10,5",
+        "iPhone10,6",
+        "iPhone11,2",
+        "iPhone11,4",
+        "iPhone11,6",
+        "iPhone11,8",
+        "iPhone12,1",
+        "iPhone12,3",
+        "iPhone12,5",
+        "iPhone12,8",
+        "iPhone13,1",
+        "iPhone13,2",
+        "iPhone13,3",
+        "iPhone13,4",
+        "iPhone14,2",
+        "iPhone14,3",
+        "iPhone14,4",
+        "iPhone14,5",
+        "iPhone14,6"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "iPhone10,1",
+                "iPhone10,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53443/E7AE2ADA-E668-4AA4-B0FA-DE10ACE60E8D/iPhone_4.7_P3_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53443/E7AE2ADA-E668-4AA4-B0FA-DE10ACE60E8D/iPhone_4.7_P3_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5630345864,
+            "hashes": {
+                "sha2-256": "4b195695540e4b4a184e7ab4390ea521711617b21828f7085e82b663122517ee",
+                "sha1": "f4e664c4d8c5fcd67e8b6605e7dfeb44551623d5"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone10,2",
+                "iPhone10,5"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53495/A8476AB7-3B88-4DBB-9845-4910969AB405/iPhone_5.5_P3_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53495/A8476AB7-3B88-4DBB-9845-4910969AB405/iPhone_5.5_P3_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5748184062,
+            "hashes": {
+                "sha2-256": "54d961aa79daeddadad48bece273d731d352c8f1adfaff57dab7fde7fb7fb95e",
+                "sha1": "78cab72f476177f776c7929be7a61f8f060c9dd9"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone10,3",
+                "iPhone10,6"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53375/94D50E5A-B200-4C7C-9C67-7D9C67512527/iPhone10,3,iPhone10,6_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53375/94D50E5A-B200-4C7C-9C67-7D9C67512527/iPhone10,3,iPhone10,6_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5763468638,
+            "hashes": {
+                "sha2-256": "ce324fa54276722edc0bedacf2b34066201ab5d908599d6bd6ce7cb0e2771d1e",
+                "sha1": "978484ca1dd37956e2ea2a8e4d7b4e687abcffb6"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone11,2",
+                "iPhone11,4",
+                "iPhone11,6"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53507/BA828AB2-A9F4-4A59-AEAD-01CFE3A162A6/iPhone11,2,iPhone11,4,iPhone11,6_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53507/BA828AB2-A9F4-4A59-AEAD-01CFE3A162A6/iPhone11,2,iPhone11,4,iPhone11,6_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6202459071,
+            "hashes": {
+                "sha2-256": "126b022e575debb0265a0ccfbf7619bd83053f8f2a2a6336eee50bd0df2d6858",
+                "sha1": "d5d1dacd3b5d0fb062e10a391aa006cd95a1bfb9"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone11,8"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53538/1286DC7D-D8AC-4024-B24A-120F3EF852F1/iPhone11,8_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53538/1286DC7D-D8AC-4024-B24A-120F3EF852F1/iPhone11,8_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6069707589,
+            "hashes": {
+                "sha2-256": "304cecb32b90fb9f58540d4d8855b4e38a3f793c5166f3121fb387f95e787558",
+                "sha1": "591a162045d159c26d3bd254f94fdf60ceac7753"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone12,1"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53362/4300A2EB-EBF6-4083-AE76-64F11200E787/iPhone12,1_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53362/4300A2EB-EBF6-4083-AE76-64F11200E787/iPhone12,1_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5988064294,
+            "hashes": {
+                "sha2-256": "24b000f6233bf5b58e645b3af53dd93fc1f233f7a30cedbc7fa4517894e21634",
+                "sha1": "4c1092db89a20ca7dc1ec9ef83238ed125cabd00"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone12,3",
+                "iPhone12,5"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53474/0A63EC04-335C-494C-A067-83522CDDEA19/iPhone12,3,iPhone12,5_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53474/0A63EC04-335C-494C-A067-83522CDDEA19/iPhone12,3,iPhone12,5_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6110283343,
+            "hashes": {
+                "sha2-256": "d22445df3a27a44e93320de229d5e8334b6464ba9de2ce70afd69fb94a1780b0",
+                "sha1": "ffae2a2dd5f856e83162e0e6dba154872c5f2f41"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone12,8"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53486/372B34CD-72E5-440C-A476-622DEFCB0C60/iPhone12,8_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53486/372B34CD-72E5-440C-A476-622DEFCB0C60/iPhone12,8_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5956983520,
+            "hashes": {
+                "sha2-256": "84dd5ca4bb4654dbf1e62b568a647a5336b2cbdfe58f42182d93d67d0f8484b9",
+                "sha1": "9669da7cd7cd7b87197710d600dbcd64845da03b"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone13,1"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53512/96A08436-1E49-4B39-93C0-ED0C2A1D3A7C/iPhone13,1_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53512/96A08436-1E49-4B39-93C0-ED0C2A1D3A7C/iPhone13,1_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6230273386,
+            "hashes": {
+                "sha2-256": "3fdd8a553183f29765ff7f6314577d5b6683938b766df08ccc4f4887cbe22bb2",
+                "sha1": "06b6c5233c1e4ab7e40d9d691f1c6f49bf6fb7f8"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone13,2",
+                "iPhone13,3"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53422/7A486823-AB10-43C1-B49B-091321631835/iPhone13,2,iPhone13,3_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53422/7A486823-AB10-43C1-B49B-091321631835/iPhone13,2,iPhone13,3_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6392994186,
+            "hashes": {
+                "sha2-256": "3611bffb5c4bdabafd4f755e7d9a0fb3d2b4ebb9f1720e2ffcc939b6599a9ba7",
+                "sha1": "4edf89693c88a334d2ca55b3fe3ba8ccca452784"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone13,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53355/EEEDA2B3-E9A8-4BAB-B9A5-FB8FDD17A88B/iPhone13,4_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53355/EEEDA2B3-E9A8-4BAB-B9A5-FB8FDD17A88B/iPhone13,4_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6348923465,
+            "hashes": {
+                "sha2-256": "e5a85612f77b991fc0fdecfa8c7d5af213b149f6859f25e3696d10a882c81cb0",
+                "sha1": "b032ce612f850c19f835adde444a437fe7db0549"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone14,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53468/07D60326-5420-468F-A298-7B03735EB188/iPhone14,2_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53468/07D60326-5420-468F-A298-7B03735EB188/iPhone14,2_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6392559242,
+            "hashes": {
+                "sha2-256": "357f02ceb9bd90640cf91a71f33fbf1636c855e4cc6cb8ccd40b8c6188b314bf",
+                "sha1": "faf9287eb33f914848356b14e48bd97811024434"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone14,3"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53344/EE9B3E60-100B-4809-B69B-DFFFE8C330FC/iPhone14,3_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53344/EE9B3E60-100B-4809-B69B-DFFFE8C330FC/iPhone14,3_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6392921069,
+            "hashes": {
+                "sha2-256": "17fdaf9070967b9032a94b741a69241c3ff84f8270d291d005575fb887c5b25c",
+                "sha1": "6a2255d7081e39a000c13f4386b2bc44f5782dbe"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone14,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53494/525D822B-00A4-4632-A7AD-934C08147978/iPhone14,4_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53494/525D822B-00A4-4632-A7AD-934C08147978/iPhone14,4_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6309470742,
+            "hashes": {
+                "sha2-256": "c752e86ad6290b474ceaab66b2acdce1f28dfad982a94c4a5f1ad24ecc94c423",
+                "sha1": "e687a5f509d790f7bfd5375698b1c5a8e53f7375"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone14,5"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53412/3A346053-FE1E-44C8-AACB-991337024DFC/iPhone14,5_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53412/3A346053-FE1E-44C8-AACB-991337024DFC/iPhone14,5_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6282674373,
+            "hashes": {
+                "sha2-256": "148ce8ce092b8e148d15e1378685576d01ebff40c83a7d0edab8aaf3ec60d204",
+                "sha1": "72a48687eebed09b1e02815778c24560aca73e91"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone14,6"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53365/ACDB7C5A-2E77-4702-822B-3DC70983CC83/iPhone14,6_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53365/ACDB7C5A-2E77-4702-822B-3DC70983CC83/iPhone14,6_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6094836228,
+            "hashes": {
+                "sha2-256": "b4ab2da948aed7f11f2c8726e4344b3640e1cac6f26d9230c0fa02473fee0b65",
+                "sha1": "672c8b10fb9fb09868a06ca0b84e005c3bb2516a"
+            }
+        }
+    ]
+}

--- a/iosFiles/iPadOS/20x - 16.x/20A5349b.json
+++ b/iosFiles/iPadOS/20x - 16.x/20A5349b.json
@@ -1,0 +1,393 @@
+{
+    "osStr": "iPadOS",
+    "version": "16.0 beta 6",
+    "build": "20A5349b",
+    "released": "2022-08-15",
+    "beta": true,
+    "deviceMap": [
+        "iPad6,3",
+        "iPad6,4",
+        "iPad6,7",
+        "iPad6,8",
+        "iPad6,11",
+        "iPad6,12",
+        "iPad7,1",
+        "iPad7,2",
+        "iPad7,3",
+        "iPad7,4",
+        "iPad7,5",
+        "iPad7,6",
+        "iPad7,11",
+        "iPad7,12",
+        "iPad8,1",
+        "iPad8,2",
+        "iPad8,3",
+        "iPad8,4",
+        "iPad8,5",
+        "iPad8,6",
+        "iPad8,7",
+        "iPad8,8",
+        "iPad8,9",
+        "iPad8,10",
+        "iPad8,11",
+        "iPad8,12",
+        "iPad11,1",
+        "iPad11,2",
+        "iPad11,3",
+        "iPad11,4",
+        "iPad11,6",
+        "iPad11,7",
+        "iPad12,1",
+        "iPad12,2",
+        "iPad13,1",
+        "iPad13,2",
+        "iPad13,4",
+        "iPad13,5",
+        "iPad13,6",
+        "iPad13,7",
+        "iPad13,8",
+        "iPad13,9",
+        "iPad13,10",
+        "iPad13,11",
+        "iPad13,16",
+        "iPad13,17",
+        "iPad14,1",
+        "iPad14,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "iPad7,11",
+                "iPad7,12"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53308/AA04AF65-6C9C-47E9-B87B-ED9AAB501C1C/iPad_10.2_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53308/AA04AF65-6C9C-47E9-B87B-ED9AAB501C1C/iPad_10.2_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5201232056,
+            "hashes": {
+                "sha2-256": "d4765a06821a7f82a5a8d4c3cda303d4a44f514fc4435c3fed28497625c6a669",
+                "sha1": "6253e6822f382568ec1cb258ddbf0715a7540d4f"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad11,6",
+                "iPad11,7"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53487/977F3BE2-C2EE-4448-84F5-8B4EDBA4D859/iPad_10.2_2020_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53487/977F3BE2-C2EE-4448-84F5-8B4EDBA4D859/iPad_10.2_2020_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5754757305,
+            "hashes": {
+                "sha2-256": "5f0bd6fc6a30ec78f852b36e3b6b7846531a9d263d54518daa0717c0b7c16291",
+                "sha1": "2b8c531c2f34952379a782c2e6b03b214eff5df4"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad12,1",
+                "iPad12,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53449/229F6F4D-8C31-4B6B-9985-BAA8D7115FB8/iPad_10.2_2021_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53449/229F6F4D-8C31-4B6B-9985-BAA8D7115FB8/iPad_10.2_2021_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5651625949,
+            "hashes": {
+                "sha2-256": "6b2615196b0bffe497cc3706eb34ea2913fcd345a81b5385011706a05a688404",
+                "sha1": "ffbcdd4f6fdab72e9bf4ecfbd78448f0926ddc11"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad6,11",
+                "iPad6,12",
+                "iPad7,5",
+                "iPad7,6"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53388/C19A11DA-B746-4309-BD52-49F70AE2EB50/iPad_64bit_TouchID_ASTC_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53388/C19A11DA-B746-4309-BD52-49F70AE2EB50/iPad_64bit_TouchID_ASTC_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5322851810,
+            "hashes": {
+                "sha2-256": "eef1455c7033ae667c34a377f00b5600cd610bef239286998457b4e741f5e5ba",
+                "sha1": "9f57f77c7cc06c03179f8bb77b5185df5595e075"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad13,1",
+                "iPad13,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53301/B3D789A5-F755-4C44-92CC-E6D4C5C9B4C4/iPad_Fall_2020_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53301/B3D789A5-F755-4C44-92CC-E6D4C5C9B4C4/iPad_Fall_2020_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5681689635,
+            "hashes": {
+                "sha2-256": "1eab1c7dda6bc1e849c80603808265f89add6179d3bde5c98ad42f3d14935f1b",
+                "sha1": "8da63145aa1e8e8232ff880cb9ccead698ee4e55"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad14,1",
+                "iPad14,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53546/7623DE77-EC6B-4FB3-BB2B-8FD657463035/iPad_Fall_2021_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53546/7623DE77-EC6B-4FB3-BB2B-8FD657463035/iPad_Fall_2021_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5781887669,
+            "hashes": {
+                "sha2-256": "d31c162cb200407bf3b5b762db3095df6a28dfc1c9bbbd02e04e641f96c26d94",
+                "sha1": "e579a375429504f5ea42b3b84b5ca6c2ee6273b0"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad6,3",
+                "iPad6,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53489/D903A2AF-5F8E-47FD-931A-A0C0F525BC3B/iPadPro_9.7_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53489/D903A2AF-5F8E-47FD-931A-A0C0F525BC3B/iPadPro_9.7_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5152616204,
+            "hashes": {
+                "sha2-256": "adc0524ed25f63b86669b3a9fd2a5ad0ad489538b5bfd370891d26b6d328a059",
+                "sha1": "17ae7bafdc1adc33e5e986b5a54aa24c31cba707"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad6,7",
+                "iPad6,8"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53431/8C39FD09-BF36-4433-BFEE-29C731A2BBFD/iPadPro_12.9_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53431/8C39FD09-BF36-4433-BFEE-29C731A2BBFD/iPadPro_12.9_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5144822807,
+            "hashes": {
+                "sha2-256": "30cf68d5881801b477f373217c834fea0ca940701d1c2869271144befc022660",
+                "sha1": "7709cc21274e487e2c0b0083c70c09cb63ea64d2"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad8,1",
+                "iPad8,10",
+                "iPad8,11",
+                "iPad8,12",
+                "iPad8,2",
+                "iPad8,3",
+                "iPad8,4",
+                "iPad8,5",
+                "iPad8,6",
+                "iPad8,7",
+                "iPad8,8",
+                "iPad8,9"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53312/84232B14-351F-451C-9853-E9558F0111CC/iPad_Pro_A12X_A12Z_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53312/84232B14-351F-451C-9853-E9558F0111CC/iPad_Pro_A12X_A12Z_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6065959356,
+            "hashes": {
+                "sha2-256": "27e25280043c5462eb84d7455d56e5de604a11bf4bcb4c54714de94fb3e33e80",
+                "sha1": "15bee7bc1a5ab72df0c00a49c3b4fa958e672250"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad7,1",
+                "iPad7,2",
+                "iPad7,3",
+                "iPad7,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53448/8BEC0F3E-CBA4-4C2A-9902-3A8F87B47105/iPad_Pro_HFR_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53448/8BEC0F3E-CBA4-4C2A-9902-3A8F87B47105/iPad_Pro_HFR_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5196853175,
+            "hashes": {
+                "sha2-256": "19075cee7153f42ecb7a4f92a183d1dcfdf4d8c75547111a149191cca44713be",
+                "sha1": "46f07d63c5c12c22a655662c0b86c99e11451969"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad13,10",
+                "iPad13,11",
+                "iPad13,4",
+                "iPad13,5",
+                "iPad13,6",
+                "iPad13,7",
+                "iPad13,8",
+                "iPad13,9"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53540/32881E7C-AAC7-45CE-AAEE-7102B5C6F4E8/iPad_Pro_Spring_2021_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53540/32881E7C-AAC7-45CE-AAEE-7102B5C6F4E8/iPad_Pro_Spring_2021_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5917019089,
+            "hashes": {
+                "sha2-256": "087578553036049a272c8732462ff2e0afa0af67db6f1b2ed09d0edf11eb5df1",
+                "sha1": "cd37ce78bac982ac35b4a74f71f8ba014defd3d8"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad11,1",
+                "iPad11,2",
+                "iPad11,3",
+                "iPad11,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53550/AA563B88-AAF4-4849-BD30-8BAEC624F32E/iPad_Spring_2019_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53550/AA563B88-AAF4-4849-BD30-8BAEC624F32E/iPad_Spring_2019_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5792914024,
+            "hashes": {
+                "sha2-256": "22dc5613ee9daf63d25736c1847d3064a0a05bd3e546cf85c077e38e683ed0af",
+                "sha1": "75da4318d64e1338ebb17062f23f2d0f6471a28d"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad13,16",
+                "iPad13,17"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-53539/47365560-826A-498E-8D37-5CCA80BD39AB/iPad_Spring_2022_16.0_20A5349b_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-53539/47365560-826A-498E-8D37-5CCA80BD39AB/iPad_Spring_2022_16.0_20A5349b_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5794633230,
+            "hashes": {
+                "sha2-256": "9eed699dc302761592dc8969290562c184e5aae056b0d7fa3fb558c3a2d44a4f",
+                "sha1": "0c9557b349e0772f594f24b7c1f4fa3dce3863f5"
+            }
+        }
+    ]
+}

--- a/iosFiles/tvOS/20x - 16.x/20J5366a.json
+++ b/iosFiles/tvOS/20x - 16.x/20J5366a.json
@@ -1,0 +1,35 @@
+{
+    "osStr": "tvOS",
+    "version": "16.0 beta 6",
+    "build": "20J5366a",
+    "released": "2022-08-15",
+    "beta": true,
+    "deviceMap": [
+        "AppleTV5,3"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "AppleTV5,3"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerSeed/fullrestores/012-55654/AD1A1EFB-22E4-4985-8C4B-6AA65D0AFBCC/AppleTV5,3_16.0_20J5366a_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerSeed/fullrestores/012-55654/AD1A1EFB-22E4-4985-8C4B-6AA65D0AFBCC/AppleTV5,3_16.0_20J5366a_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 3540506388,
+            "hashes": {
+                "sha2-256": "f41e2470350171e506ef901e63abd73be2cfa0ca13e36ce6af5fb0145bc38bef",
+                "sha1": "beca6b122eaedd6a779bf79510cdb1c430f28540"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Add firmware info and ipsw links for iOS and tvOS 16.0b6.

Still missing the firmwares without ipsws: watchOS, audioOS, and tvOS deviceMap should have AppleTV 4K.