### PR TITLE
Add today's iOS 15.6.1 and macOS 12.5.1

### DIFF
--- a/iosFiles/iOS/19x - 15.x/19G82.json
+++ b/iosFiles/iOS/19x - 15.x/19G82.json
@@ -1,0 +1,470 @@
+{
+    "osStr": "iOS",
+    "version": "15.6.1",
+    "build": "19G82",
+    "released": "2022-08-17",
+    "release_notes": "https://support.apple.com/HT212788#1561",
+    "security_notes": "https://support.apple.com/HT213412",
+    "deviceMap": [
+        "iPhone8,1",
+        "iPhone8,2",
+        "iPhone8,4",
+        "iPhone9,1",
+        "iPhone9,2",
+        "iPhone9,3",
+        "iPhone9,4",
+        "iPhone10,1",
+        "iPhone10,2",
+        "iPhone10,3",
+        "iPhone10,4",
+        "iPhone10,5",
+        "iPhone10,6",
+        "iPhone11,2",
+        "iPhone11,4",
+        "iPhone11,6",
+        "iPhone11,8",
+        "iPhone12,1",
+        "iPhone12,3",
+        "iPhone12,5",
+        "iPhone12,8",
+        "iPhone13,1",
+        "iPhone13,2",
+        "iPhone13,3",
+        "iPhone13,4",
+        "iPhone14,2",
+        "iPhone14,3",
+        "iPhone14,4",
+        "iPhone14,5",
+        "iPhone14,6",
+        "iPod9,1"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "iPhone8,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-53076/DAD300FD-EA55-4458-AA3E-6BA875C4B3A1/iPhone_4.0_64bit_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-53076/DAD300FD-EA55-4458-AA3E-6BA875C4B3A1/iPhone_4.0_64bit_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5229523837,
+            "hashes": {
+                "sha2-256": "5b75e9c703a097516eda0a23950be5983e615025afb637cf01325946544e1d63",
+                "sha1": "2e8f01eb43db77723c41bc6d1437053fab5a8cb9"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone8,1"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52552/90DDC844-B111-4CBF-8C86-E2A8B604B3D2/iPhone_4.7_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52552/90DDC844-B111-4CBF-8C86-E2A8B604B3D2/iPhone_4.7_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5269328424,
+            "hashes": {
+                "sha2-256": "ce942c2cae5cc0305914949d58589cb7689b917d85b77551917b9739f596f4a3",
+                "sha1": "3f24a89a67a73ae212b247d808bf6e4e6bab5805"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone10,1",
+                "iPhone10,4",
+                "iPhone9,1",
+                "iPhone9,3"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52712/26BB2FC1-230F-460A-8DEB-D361479973EC/iPhone_4.7_P3_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52712/26BB2FC1-230F-460A-8DEB-D361479973EC/iPhone_4.7_P3_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5636691801,
+            "hashes": {
+                "sha2-256": "59c2f66da2825f1cf4404274e16a6ef0d61c344f4d298345eeeb47b7868d16fd",
+                "sha1": "8ab1e6e4943aaf30dec2b1c0048587b2a3f800a5"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone8,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52595/6E67AF64-825E-4778-9301-F25A4E8EEF37/iPhone_5.5_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52595/6E67AF64-825E-4778-9301-F25A4E8EEF37/iPhone_5.5_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5427438652,
+            "hashes": {
+                "sha2-256": "8d96b95d3b9c7d3dd14766f2a43fb7869169608864a500d0476b3d3172a8789c",
+                "sha1": "b4a9a8cd1feb16c4158fdb2e03854f96c7a8a795"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone10,2",
+                "iPhone10,5",
+                "iPhone9,2",
+                "iPhone9,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52889/B5338EBD-ED5C-4637-A829-6A269A2BD916/iPhone_5.5_P3_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52889/B5338EBD-ED5C-4637-A829-6A269A2BD916/iPhone_5.5_P3_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5799168023,
+            "hashes": {
+                "sha2-256": "2ab7826018dd662aa862777f31569e17091a44e8655f021d31f72091956a2a49",
+                "sha1": "f90d311ddb5808ad6fc8ef73da919752eb4a9fec"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone10,3",
+                "iPhone10,6"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52718/E165707F-2AA7-40C8-B1A5-0BB94E3F845A/iPhone10,3,iPhone10,6_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52718/E165707F-2AA7-40C8-B1A5-0BB94E3F845A/iPhone10,3,iPhone10,6_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5777710157,
+            "hashes": {
+                "sha2-256": "e59be5b34321f712beecbffd6c350ba28a5e56427d16b1f139ef7b6cc5d5455f",
+                "sha1": "5f1cd54665372ccaeb6fe6ab971ca88c6d378e79"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone11,2",
+                "iPhone11,4",
+                "iPhone11,6",
+                "iPhone12,3",
+                "iPhone12,5"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52967/DCE2CEF4-E428-4B8B-8A46-1C05E239E728/iPhone11,2,iPhone11,4,iPhone11,6,iPhone12,3,iPhone12,5_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52967/DCE2CEF4-E428-4B8B-8A46-1C05E239E728/iPhone11,2,iPhone11,4,iPhone11,6,iPhone12,3,iPhone12,5_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 7260180209,
+            "hashes": {
+                "sha2-256": "2f45d7c4425f0fcfc890fa800566ad8a122e2c54b6063b9fe1b5475bd83207ea",
+                "sha1": "27b483324fc54a4f3156add74f448993316032f9"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone11,8",
+                "iPhone12,1"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52696/AA3B1C19-3E2D-4A65-BF5D-8563C9D719BE/iPhone11,8,iPhone12,1_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52696/AA3B1C19-3E2D-4A65-BF5D-8563C9D719BE/iPhone11,8,iPhone12,1_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6787399189,
+            "hashes": {
+                "sha2-256": "8bef727e8fb4a5b229cba490e69a2d5e1a4cd992c433eb3ae54dcffc65f67253",
+                "sha1": "b12f96e8aa87885a5f7732b71b809b2f3d7107d4"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone12,8"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52400/C76C51A6-2DD7-4F78-9E36-BBB511F85908/iPhone12,8_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52400/C76C51A6-2DD7-4F78-9E36-BBB511F85908/iPhone12,8_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5952609739,
+            "hashes": {
+                "sha2-256": "8caea125a5c89b39ce5d9b87497885b2eeef0bb3e1cf1ed6adc90ee249dfc3cc",
+                "sha1": "ed53540ee6580fdfebab016a2ed59a5ba05ff442"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone13,1"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52698/7F9356E8-F0EA-4BD9-8E8E-64D71AF1EEB4/iPhone13,1_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52698/7F9356E8-F0EA-4BD9-8E8E-64D71AF1EEB4/iPhone13,1_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6430879658,
+            "hashes": {
+                "sha2-256": "45cb2c845ac5106e580696f2eefcce7623bb10a1039704deae1e9315227828d6",
+                "sha1": "c5e9618577ca89a7dd32d4209eccb1d92a9d3a90"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone13,2",
+                "iPhone13,3"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52662/8690354D-5AA6-4678-91ED-52BD3ED1CD0C/iPhone13,2,iPhone13,3_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52662/8690354D-5AA6-4678-91ED-52BD3ED1CD0C/iPhone13,2,iPhone13,3_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6682093027,
+            "hashes": {
+                "sha2-256": "7b6afc2cfc25fd508c43489d2965cc8f19a30dd8c593cc85ac981a1083e179e9",
+                "sha1": "1918382932f46e87b418307defc58ce1e2d45318"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone13,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-53121/781B38B9-5A72-4F6D-AA98-ADB074F000DC/iPhone13,4_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-53121/781B38B9-5A72-4F6D-AA98-ADB074F000DC/iPhone13,4_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6534415028,
+            "hashes": {
+                "sha2-256": "b4b274c206347c1b68495030a816ee2e4c1edae72f327447e97b41a38e8b22a1",
+                "sha1": "0ced9c8c388fd5a95de6e613763ed9b1bf24b4d0"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone14,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52415/04B2D458-9F17-4937-8ECB-60BB805C3BBB/iPhone14,2_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52415/04B2D458-9F17-4937-8ECB-60BB805C3BBB/iPhone14,2_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6533364269,
+            "hashes": {
+                "sha2-256": "7afe7441c5fc90c8b1ad7b323e55a3fa757ec6a24db3b4016bc18b418fd416e1",
+                "sha1": "ab372f697dc9bc12fb4118f88129627f3b4e5130"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone14,3"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52164/8C0BBF98-ABAF-4B5F-A278-02E7FDB52C34/iPhone14,3_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52164/8C0BBF98-ABAF-4B5F-A278-02E7FDB52C34/iPhone14,3_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6572828908,
+            "hashes": {
+                "sha2-256": "3dfdfc4393ba47dcf63d63b37c7a0e91e807096f2d60cc6d65b6faa2fc001fb9",
+                "sha1": "919b52e0eebd782c46baea0408b8ac9721d98399"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone14,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52747/C3BCF7F5-EE6F-488E-9842-7C4E2EB9DAB9/iPhone14,4_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52747/C3BCF7F5-EE6F-488E-9842-7C4E2EB9DAB9/iPhone14,4_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6483381892,
+            "hashes": {
+                "sha2-256": "0c4ee058fb5d80f705c14f49f046a36ca858e00163dd9dc2d225c2bc62909d92",
+                "sha1": "5c802126a058d72bf661ccb210f133d859f6d2ad"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone14,5"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52790/1375B597-6A2A-4C60-8B78-C9AC84C4475F/iPhone14,5_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52790/1375B597-6A2A-4C60-8B78-C9AC84C4475F/iPhone14,5_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6492110462,
+            "hashes": {
+                "sha2-256": "5df9de0dbbbea3c4526aa409a02630a5283483fd1d588321d49c045d52033cf5",
+                "sha1": "8387d4127fead0be07500bba24c7184a1315ea5b"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPhone14,6"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52672/8C68D6B3-9EDE-46EA-9BBD-4C16ADAAA1C5/iPhone14,6_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52672/8C68D6B3-9EDE-46EA-9BBD-4C16ADAAA1C5/iPhone14,6_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6058405437,
+            "hashes": {
+                "sha2-256": "85b90c269c2df283fad92e89bcadcdd21585f9f3bffdb185278aa06eab321eb9",
+                "sha1": "2f3fd70a9288d2033bb266606c1335b76df543ec"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPod9,1"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52627/DD300F48-BDC8-4A19-9BC7-37587D2F14E9/iPodtouch_7_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52627/DD300F48-BDC8-4A19-9BC7-37587D2F14E9/iPodtouch_7_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5013586938,
+            "hashes": {
+                "sha2-256": "39c041686ea12a7db91dd41e0b1e8b85f9d15a29e4cec415272cdeb878cb1d50",
+                "sha1": "4a65faa31dbd306db1f8561a656382cf6763f658"
+            }
+        }
+    ]
+}

--- a/iosFiles/iPadOS/19x - 15.x/19G82.json
+++ b/iosFiles/iPadOS/19x - 15.x/19G82.json
@@ -1,0 +1,424 @@
+{
+    "osStr": "iPadOS",
+    "version": "15.6.1",
+    "build": "19G82",
+    "released": "2022-08-17",
+    "release_notes": "https://support.apple.com/HT212788#1561",
+    "security_notes": "https://support.apple.com/HT213412",
+    "deviceMap": [
+        "iPad5,1",
+        "iPad5,2",
+        "iPad5,3",
+        "iPad5,4",
+        "iPad6,3",
+        "iPad6,4",
+        "iPad6,7",
+        "iPad6,8",
+        "iPad6,11",
+        "iPad6,12",
+        "iPad7,1",
+        "iPad7,2",
+        "iPad7,3",
+        "iPad7,4",
+        "iPad7,5",
+        "iPad7,6",
+        "iPad7,11",
+        "iPad7,12",
+        "iPad8,1",
+        "iPad8,2",
+        "iPad8,3",
+        "iPad8,4",
+        "iPad8,5",
+        "iPad8,6",
+        "iPad8,7",
+        "iPad8,8",
+        "iPad8,9",
+        "iPad8,10",
+        "iPad8,11",
+        "iPad8,12",
+        "iPad11,1",
+        "iPad11,2",
+        "iPad11,3",
+        "iPad11,4",
+        "iPad11,6",
+        "iPad11,7",
+        "iPad12,1",
+        "iPad12,2",
+        "iPad13,1",
+        "iPad13,2",
+        "iPad13,4",
+        "iPad13,5",
+        "iPad13,6",
+        "iPad13,7",
+        "iPad13,8",
+        "iPad13,9",
+        "iPad13,10",
+        "iPad13,11",
+        "iPad13,16",
+        "iPad13,17",
+        "iPad14,1",
+        "iPad14,2"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "iPad6,3",
+                "iPad6,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52159/1499A7D6-07FF-4FF3-9ACA-AA46A72D9950/iPadPro_9.7_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52159/1499A7D6-07FF-4FF3-9ACA-AA46A72D9950/iPadPro_9.7_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5089350910,
+            "hashes": {
+                "sha2-256": "8a1fb6ed6f963420d63eeab298da58e477b827a50c6d14ddfdd002277c549510",
+                "sha1": "fea823e16255df919579909a5ce23475a66b7d91"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad6,7",
+                "iPad6,8"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52262/C7DF205A-8BCF-46EC-BBF4-2BB5B35BC019/iPadPro_12.9_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52262/C7DF205A-8BCF-46EC-BBF4-2BB5B35BC019/iPadPro_12.9_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5209826258,
+            "hashes": {
+                "sha2-256": "95f49ed973a0b2b24c295cf76909c4d904e3e68a569a04776ce2345e677791ae",
+                "sha1": "c9a8e55aaa8d971d29eb824d8dc8534744ca6874"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad7,11",
+                "iPad7,12"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52155/B842569C-B688-44DA-9058-9B8DC5936A52/iPad_10.2_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52155/B842569C-B688-44DA-9058-9B8DC5936A52/iPad_10.2_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5149837897,
+            "hashes": {
+                "sha2-256": "3302950194a538c69289f44d81f3cf489f43c6b0fe4d9772168a360130c5d67b",
+                "sha1": "d15fbe8c9bd9ead9bed663a316f29cdfa4ae7374"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad11,6",
+                "iPad11,7"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52945/1DDAEEA6-1C96-440C-9DBA-6F4D33F57135/iPad_10.2_2020_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52945/1DDAEEA6-1C96-440C-9DBA-6F4D33F57135/iPad_10.2_2020_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5719680272,
+            "hashes": {
+                "sha2-256": "dfa04d8599142b6647971c6ffb51e5d3773ab2cae813bf161fe163d9c98c2ec4",
+                "sha1": "83db5fc5352276303e01788c9f0f2eefc519c0aa"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad12,1",
+                "iPad12,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52847/DFAA9670-26D9-4946-A9F8-9ED9CFC11335/iPad_10.2_2021_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52847/DFAA9670-26D9-4946-A9F8-9ED9CFC11335/iPad_10.2_2021_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5635461978,
+            "hashes": {
+                "sha2-256": "69d413db1bc6480242ae60ba0f4280d91b25c0af0559df2fdd43fc72b184734b",
+                "sha1": "11afab81544bde790b4793ecc6a2a96fb7fc0ced"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad5,1",
+                "iPad5,2",
+                "iPad5,3",
+                "iPad5,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52944/7F21F4D8-03C9-45D1-AB60-A7CF99B64DB9/iPad_64bit_TouchID_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52944/7F21F4D8-03C9-45D1-AB60-A7CF99B64DB9/iPad_64bit_TouchID_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5046206753,
+            "hashes": {
+                "sha2-256": "afcd8e26d0bc2f71356aca2dad254f374b08d9e402a32e2663c5a03e94bc0c03",
+                "sha1": "c8883712a9ee8e40ec33a9d0b7c77b18671c6f07"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad6,11",
+                "iPad6,12",
+                "iPad7,5",
+                "iPad7,6"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52633/AC5BDCA4-7C06-40CD-A61C-65DCF1BBDE3E/iPad_64bit_TouchID_ASTC_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52633/AC5BDCA4-7C06-40CD-A61C-65DCF1BBDE3E/iPad_64bit_TouchID_ASTC_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5226142334,
+            "hashes": {
+                "sha2-256": "70570296a78090853215c68dc4bc8df75f00c943fa714b1fb12517fba83f461a",
+                "sha1": "478a00c0bf4411dd3984699de0f4c700967e15d5"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad13,1",
+                "iPad13,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52333/089AFE1C-ACCD-4167-AB01-B5A4BF6597E4/iPad_Fall_2020_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52333/089AFE1C-ACCD-4167-AB01-B5A4BF6597E4/iPad_Fall_2020_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5727960277,
+            "hashes": {
+                "sha2-256": "b1adb5747b41817a174387d8ce8790b496586adba51f07275f59f98564f61aa4",
+                "sha1": "62cd5a15a15af22b91cb92ef6e5c36aa2c2c8695"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad14,1",
+                "iPad14,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-53130/667A9F96-0B0E-4641-878F-48844EEA398C/iPad_Fall_2021_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-53130/667A9F96-0B0E-4641-878F-48844EEA398C/iPad_Fall_2021_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5829267751,
+            "hashes": {
+                "sha2-256": "9bccfe40d47344b9cae09de7f06ffc20448bccd68d4e69d43fdd601218c93a9a",
+                "sha1": "74a37f34dba73340d0cc4f4ea5b0f2e58da70617"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad8,1",
+                "iPad8,10",
+                "iPad8,11",
+                "iPad8,12",
+                "iPad8,2",
+                "iPad8,3",
+                "iPad8,4",
+                "iPad8,5",
+                "iPad8,6",
+                "iPad8,7",
+                "iPad8,8",
+                "iPad8,9"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52940/01502C4C-495B-483C-ABB3-319509F4C0EE/iPad_Pro_A12X_A12Z_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52940/01502C4C-495B-483C-ABB3-319509F4C0EE/iPad_Pro_A12X_A12Z_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6401601893,
+            "hashes": {
+                "sha2-256": "5becbb33448b4b10f79cf231656788f9f8edcd2e544490c513476c350550e655",
+                "sha1": "6d6fe0df66c50a78db70cf46de4993971b8b4dd4"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad7,1",
+                "iPad7,2",
+                "iPad7,3",
+                "iPad7,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52928/761AA194-A2ED-430D-A355-F1533029A377/iPad_Pro_HFR_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52928/761AA194-A2ED-430D-A355-F1533029A377/iPad_Pro_HFR_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5347575339,
+            "hashes": {
+                "sha2-256": "5cf6e15c948b26b16e0b92cda94da006a68b9cd0a6d2594bcbc8e04dea2949ff",
+                "sha1": "c73029a9b0821e24c6f89bda3ece8fb964541792"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad13,10",
+                "iPad13,11",
+                "iPad13,4",
+                "iPad13,5",
+                "iPad13,6",
+                "iPad13,7",
+                "iPad13,8",
+                "iPad13,9"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-53127/DDDA0855-416A-4C8A-AAC7-F18D4387FDFE/iPad_Pro_Spring_2021_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-53127/DDDA0855-416A-4C8A-AAC7-F18D4387FDFE/iPad_Pro_Spring_2021_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 6250924251,
+            "hashes": {
+                "sha2-256": "496a0f283f2e4e443cad8163ef6cb14f82b9769e3f34571e81cea9dbaad02c57",
+                "sha1": "81f465efd9408fd88e57bca825c08bebfa4b3095"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad11,1",
+                "iPad11,2",
+                "iPad11,3",
+                "iPad11,4"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52145/8D085DB4-D459-4ACA-B816-6FEF5B34F271/iPad_Spring_2019_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52145/8D085DB4-D459-4ACA-B816-6FEF5B34F271/iPad_Spring_2019_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5849718012,
+            "hashes": {
+                "sha2-256": "4f46598141419bb5e80b3ceaf715839372ab828af730030aaa30e66458933e29",
+                "sha1": "c352b2b87c1b28dcff2239ae8b2586558abe3e41"
+            }
+        },
+        {
+            "deviceMap": [
+                "iPad13,16",
+                "iPad13,17"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-52227/D93D9970-02CA-4FAA-A535-798D31BB293C/iPad_Spring_2022_15.6.1_19G82_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-52227/D93D9970-02CA-4FAA-A535-798D31BB293C/iPad_Spring_2022_15.6.1_19G82_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 5841031076,
+            "hashes": {
+                "sha2-256": "eab2ab3dd3ed0f30926fe9aae7bf8065abf95695b42ac2a4ce9af40b5990494c",
+                "sha1": "c6bf2c9aecf1149adf657a8f17a2c3b7d89d109f"
+            }
+        }
+    ]
+}

--- a/iosFiles/macOS/21x - 12.x/21G83.json
+++ b/iosFiles/macOS/21x - 12.x/21G83.json
@@ -1,0 +1,62 @@
+{
+    "osStr": "macOS",
+    "version": "12.5.1",
+    "build": "21G83",
+    "released": "2022-08-17",
+    "release_notes": "https://support.apple.com/HT212585#macos1251",
+    "security_notes": "https://support.apple.com/HT213413",
+    "deviceMap": [
+        "Mac13,1",
+        "Mac13,2",
+        "Mac14,2",
+        "Mac14,7",
+        "MacBookAir10,1",
+        "MacBookPro17,1",
+        "MacBookPro18,1",
+        "MacBookPro18,2",
+        "MacBookPro18,3",
+        "MacBookPro18,4",
+        "Macmini9,1",
+        "iMac21,1",
+        "iMac21,2",
+        "VirtualMac2,1"
+    ],
+    "sources": [
+        {
+            "deviceMap": [
+                "Mac13,1",
+                "Mac13,2",
+                "Mac14,2",
+                "Mac14,7",
+                "MacBookAir10,1",
+                "MacBookPro17,1",
+                "MacBookPro18,1",
+                "MacBookPro18,2",
+                "MacBookPro18,3",
+                "MacBookPro18,4",
+                "Macmini9,1",
+                "VirtualMac2,1",
+                "iMac21,1",
+                "iMac21,2"
+            ],
+            "type": "ipsw",
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2022SummerFCS/fullrestores/012-51674/A7019DDB-3355-470F-A355-4162A187AB6C/UniversalMac_12.5.1_21G83_Restore.ipsw",
+                    "preferred": true,
+                    "active": true
+                },
+                {
+                    "url": "http://updates-http.cdn-apple.com/2022SummerFCS/fullrestores/012-51674/A7019DDB-3355-470F-A355-4162A187AB6C/UniversalMac_12.5.1_21G83_Restore.ipsw",
+                    "preferred": false,
+                    "active": true
+                }
+            ],
+            "size": 14088266331,
+            "hashes": {
+                "sha2-256": "97a5c61e21e9ddf25158ec9dca67b482205f9dd311d274a1a59915b4bb042c83",
+                "sha1": "478eca5466157a6eef5cdba8f75884b224c6d3f6"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Add JSON files for iOS 15.6.1 and macOS 12.5.1, including ipsws and release notes.