### PR TITLE
Add beta=true to "duplicate entry" release candidates

### DIFF
--- a/iosFiles/audioOS/18x - 14.x/18K802.json
+++ b/iosFiles/audioOS/18x - 14.x/18K802.json
@@ -7,7 +7,8 @@
         {
             "version": "14.4 RC",
             "uniqueBuild": "18K802-RC",
-            "released": "2021-01-21"
+            "released": "2021-01-21",
+            "beta": true
         }
     ],
     "deviceMap": [

--- a/iosFiles/audioOS/18x - 14.x/18L569.json
+++ b/iosFiles/audioOS/18x - 14.x/18L569.json
@@ -7,7 +7,8 @@
         {
             "version": "14.6 RC",
             "uniqueBuild": "18L569-RC",
-            "released": "2021-05-17"
+            "released": "2021-05-17",
+            "beta": true
         }
     ],
     "deviceMap": [

--- a/iosFiles/audioOS/18x - 14.x/18M60.json
+++ b/iosFiles/audioOS/18x - 14.x/18M60.json
@@ -7,7 +7,8 @@
         {
             "version": "14.7 RC",
             "uniqueBuild": "18M60-RC",
-            "released": "2021-07-13"
+            "released": "2021-07-13",
+            "beta": true
         }
     ],
     "deviceMap": [

--- a/iosFiles/audioOS/19x - 15.x/19J346.json
+++ b/iosFiles/audioOS/19x - 15.x/19J346.json
@@ -7,7 +7,8 @@
         {
             "version": "15.0 RC",
             "uniqueBuild": "19J346-RC",
-            "released": "2021-09-14"
+            "released": "2021-09-14",
+            "beta": true
         }
     ],
     "deviceMap": [

--- a/iosFiles/audioOS/19x - 15.x/19J572.json
+++ b/iosFiles/audioOS/19x - 15.x/19J572.json
@@ -7,7 +7,8 @@
         {
             "version": "15.1 RC",
             "uniqueBuild": "19J572-RC",
-            "released": "2021-10-18"
+            "released": "2021-10-18",
+            "beta": true
         }
     ],
     "deviceMap": [

--- a/iosFiles/audioOS/19x - 15.x/19K52.json
+++ b/iosFiles/audioOS/19x - 15.x/19K52.json
@@ -7,7 +7,8 @@
         {
             "version": "15.2 RC",
             "uniqueBuild": "19K52-RC",
-            "released": "2021-12-08"
+            "released": "2021-12-08",
+            "beta": true
         }
     ],
     "deviceMap": [

--- a/iosFiles/audioOS/19x - 15.x/19L440.json
+++ b/iosFiles/audioOS/19x - 15.x/19L440.json
@@ -7,7 +7,8 @@
         {
             "version": "15.4 RC",
             "uniqueBuild": "19L440-RC",
-            "released": "2022-03-08"
+            "released": "2022-03-08",
+            "beta": true
         }
     ],
     "deviceMap": [

--- a/iosFiles/audioOS/19x - 15.x/19L570.json
+++ b/iosFiles/audioOS/19x - 15.x/19L570.json
@@ -7,7 +7,8 @@
         {
             "version": "15.5 RC",
             "uniqueBuild": "19L570-RC",
-            "released": "2022-05-12"
+            "released": "2022-05-12",
+            "beta": true
         }
     ],
     "deviceMap": [

--- a/iosFiles/iPadOS/19x - 15.x/19G71.json
+++ b/iosFiles/iPadOS/19x - 15.x/19G71.json
@@ -7,7 +7,8 @@
         {
             "version": "15.6 RC 2",
             "uniqueBuild": "19G71-RC",
-            "released": "2022-07-15"
+            "released": "2022-07-15",
+            "beta": true
         }
     ],
     "deviceMap": [


### PR DESCRIPTION
`createDuplicateEntry` dicts for release candidates didn't have `"beta": true`; emiyl said they should have it