### PR TITLE
Add ipd links to iOS/iPadOS 15.6.1 as a first test

### DIFF
--- a/osFiles/iOS/19x - 15.x/19G82.json
+++ b/osFiles/iOS/19x - 15.x/19G82.json
@@ -5,6 +5,10 @@
     "released": "2022-08-17",
     "releaseNotes": "https://support.apple.com/HT212788#1561",
     "securityNotes": "https://support.apple.com/HT213412",
+    "ipd": {
+        "iPhone": "https://updates.cdn-apple.com/2022SummerFCS/documentation/012-55473/7C07F599-C16E-49FC-B0FD-F2A71CE4CDE0/iPhoneiOSShortRTF.ipd",
+        "iPod": "https://updates.cdn-apple.com/2022SummerFCS/documentation/012-55470/137F3285-724C-48BD-9C64-CCFE1D371E30/iPodtouchiOSShortRTF.ipd"
+    },
     "deviceMap": [
         "iPhone8,1",
         "iPhone8,2",

--- a/osFiles/iPadOS/19x - 15.x/19G82.json
+++ b/osFiles/iPadOS/19x - 15.x/19G82.json
@@ -5,6 +5,9 @@
     "released": "2022-08-17",
     "releaseNotes": "https://support.apple.com/HT212788#1561",
     "securityNotes": "https://support.apple.com/HT213412",
+    "ipd": {
+        "iPad": "https://updates.cdn-apple.com/2022SummerFCS/documentation/012-55471/57A69485-3AE6-4713-BA41-0583881AD64E/iPadShortRTF.ipd"
+    },
     "deviceMap": [
         "iPad5,1",
         "iPad5,2",

--- a/tasks/sort_os_files.py
+++ b/tasks/sort_os_files.py
@@ -24,6 +24,7 @@ key_order = [
     "notes",
     "releaseNotes",
     "securityNotes",
+    "ipd",
     "deviceMap",
     "sources",
 ]


### PR DESCRIPTION
These are files used by iTunes/Finder to show the update changelog when doing an ipsw update. They are listed on theiphonewiki.

The URL is different for iPod touch vs iPad vs iPhone, but as far as I know*, it's the same file for all iPhones on a given version. So I'm putting `"ipd": {"iPhone": "url", "iPad": "url", "iPod": "url"}` into each build json. Do you agree with this format?

(* if it turns out to be different for some iPhones/iPads, I'll find out when generating wiki pages from this, and we can figure out a different format)

What to do when there is only one device type, such as for iPadOS, or iOS 16? Should I use `"ipd": { "iPhone": "https://...iPhoneiOSShortRTF.ipd" }` or `"ipd": "https://...iPhoneiOSShortRTF.ipd"`? Personally I prefer the first because it makes things easier for consumers if `"ipd"` is *always* a dict, rather than sometimes being a string.

Bikeshedding: does it look okay to put it between securityNotes and deviceMap? Should I add it to `sort_files.py`?