### PR TITLE
Add final release of iOS 16.5 and others

### DIFF
--- a/osFiles/iOS/19x - 15.x/19H349.json
+++ b/osFiles/iOS/19x - 15.x/19H349.json
@@ -1,9 +1,16 @@
 {
     "osStr": "iOS",
-    "version": "15.7.6 RC",
+    "version": "15.7.6",
     "build": "19H349",
-    "released": "2023-05-09",
-    "rc": true,
+    "released": "2023-05-18",
+    "createDuplicateEntries": [
+        {
+            "version": "15.7.6 RC",
+            "uniqueBuild": "19H349-RC",
+            "released": "2023-05-09",
+            "rc": true
+        }
+    ],
     "deviceMap": [
         "iPhone8,1",
         "iPhone8,2",

--- a/osFiles/iOS/20x - 16.x/20F66.json
+++ b/osFiles/iOS/20x - 16.x/20F66.json
@@ -1,9 +1,17 @@
 {
     "osStr": "iOS",
-    "version": "16.5 RC 2",
+    "version": "16.5",
     "build": "20F66",
-    "released": "2023-05-15",
-    "rc": true,
+    "released": "2023-05-18",
+    "createDuplicateEntries": [
+        {
+            "version": "16.5 RC 2",
+            "uniqueBuild": "20F66-RC",
+            "released": "2023-05-15",
+            "rc": true
+        }
+    ],
+    "releaseNotes": "https://support.apple.com/HT213407#165",
     "deviceMap": [
         "iPhone10,1",
         "iPhone10,2",

--- a/osFiles/iPadOS/19x - 15.x/19H349.json
+++ b/osFiles/iPadOS/19x - 15.x/19H349.json
@@ -1,9 +1,16 @@
 {
     "osStr": "iPadOS",
-    "version": "15.7.6 RC",
+    "version": "15.7.6",
     "build": "19H349",
-    "released": "2023-05-09",
-    "rc": true,
+    "released": "2023-05-18",
+    "createDuplicateEntries": [
+        {
+            "version": "15.7.6 RC",
+            "uniqueBuild": "19H349-RC",
+            "released": "2023-05-09",
+            "rc": true
+        }
+    ],
     "deviceMap": [
         "iPad5,1",
         "iPad5,2",

--- a/osFiles/iPadOS/20x - 16.x/20F66.json
+++ b/osFiles/iPadOS/20x - 16.x/20F66.json
@@ -1,9 +1,17 @@
 {
     "osStr": "iPadOS",
-    "version": "16.5 RC 2",
+    "version": "16.5",
     "build": "20F66",
-    "released": "2023-05-15",
-    "rc": true,
+    "released": "2023-05-18",
+    "createDuplicateEntries": [
+        {
+            "version": "16.5 RC 2",
+            "uniqueBuild": "20F66-RC",
+            "released": "2023-05-15",
+            "rc": true
+        }
+    ],
+    "releaseNotes": "https://support.apple.com/HT213408#165",
     "deviceMap": [
         "iPad6,3",
         "iPad6,4",

--- a/osFiles/macOS/20x - 11.x/20G1345.json
+++ b/osFiles/macOS/20x - 11.x/20G1345.json
@@ -1,9 +1,17 @@
 {
     "osStr": "macOS",
-    "version": "11.7.7 RC 5",
+    "version": "11.7.7",
     "build": "20G1345",
-    "released": "2023-05-09",
-    "rc": true,
+    "released": "2023-05-18",
+    "createDuplicateEntries": [
+        {
+            "version": "11.7.7 RC 5",
+            "uniqueBuild": "20G1345-RC",
+            "released": "2023-05-09",
+            "rc": true
+        }
+    ],
+    "releaseNotes": "https://support.apple.com/HT211896#macos1177",
     "deviceMap": [
         "MacBookAir10,1",
         "MacBookPro17,1",

--- a/osFiles/macOS/21x - 12.x/21G646.json
+++ b/osFiles/macOS/21x - 12.x/21G646.json
@@ -1,9 +1,17 @@
 {
     "osStr": "macOS",
-    "version": "12.6.6 RC 5",
+    "version": "12.6.6",
     "build": "21G646",
-    "released": "2023-05-09",
-    "rc": true,
+    "released": "2023-05-18",
+    "createDuplicateEntries": [
+        {
+            "version": "12.6.6 RC 5",
+            "uniqueBuild": "21G646-RC",
+            "released": "2023-05-09",
+            "rc": true
+        }
+    ],
+    "releaseNotes": "https://support.apple.com/HT212585#macos1266",
     "deviceMap": [
         "Mac13,1",
         "Mac13,2",

--- a/osFiles/macOS/22x - 13.x/22F66.json
+++ b/osFiles/macOS/22x - 13.x/22F66.json
@@ -1,9 +1,17 @@
 {
     "osStr": "macOS",
-    "version": "13.4 RC 3",
+    "version": "13.4",
     "build": "22F66",
-    "released": "2023-05-16",
-    "rc": true,
+    "released": "2023-05-18",
+    "createDuplicateEntries": [
+        {
+            "version": "13.4 RC 3",
+            "uniqueBuild": "22F66-RC",
+            "released": "2023-05-16",
+            "rc": true
+        }
+    ],
+    "releaseNotes": "https://support.apple.com/HT213268#macos134",
     "deviceMap": [
         "Mac13,1",
         "Mac13,2",

--- a/osFiles/watchOS/20x - 9.x/20T562.json
+++ b/osFiles/watchOS/20x - 9.x/20T562.json
@@ -1,9 +1,17 @@
 {
     "osStr": "watchOS",
-    "version": "9.5 RC",
+    "version": "9.5",
     "build": "20T562",
-    "released": "2023-05-09",
-    "rc": true,
+    "released": "2023-05-18",
+    "createDuplicateEntries": [
+        {
+            "version": "9.5 RC",
+            "uniqueBuild": "20T562-RC",
+            "released": "2023-05-09",
+            "rc": true
+        }
+    ],
+    "releaseNotes": "https://support.apple.com/HT213436#95",
     "deviceMap": [
         "Watch4,1",
         "Watch4,2",


### PR DESCRIPTION
For all builds that had RC today, rename them to final build and move the RC stuff into createDuplicateEntries. Should save us some time on release day.

This is of course assuming there won't be an RC2 for anything, the macOS 11/12 final releases will match the last RC, etc. which is all subject to change. And this can't be merged until the dates are replaced from "2023-05-??" anyway...