### PR TITLE
Add model number to 70W Power Adapter (from product page's footnotes)…

### DIFF
--- a/deviceFiles/Power/Power Adapters/70W USB-C Power Adapter.json
+++ b/deviceFiles/Power/Power Adapters/70W USB-C Power Adapter.json
@@ -1,4 +1,5 @@
 {
-    "name": "70 USB-C Power Adapter",
-    "type": "Power"
+    "name": "70W USB-C Power Adapter",
+    "type": "Power",
+    "model": "A2743"
 }

--- a/osFiles/Bluetooth Headset Firmware/6x/6A5238h.json
+++ b/osFiles/Bluetooth Headset Firmware/6x/6A5238h.json
@@ -47,6 +47,20 @@
         {
             "type": "ota",
             "deviceMap": [
+                "AirPodsPro1,2-left",
+                "AirPodsPro1,2-right"
+            ],
+            "links": [
+                {
+                    "url": "https://updates.cdn-apple.com/2023/patches/032-83521/4F66536F-8CFB-4E9D-9976-AAD9FB0DF824/com_apple_MobileAsset_UARP_A2618/adb96d7f15f82d7dad75737435d70a80ff4d7a04.zip",
+                    "preferred": true,
+                    "active": true
+                }
+            ]
+        },
+        {
+            "type": "ota",
+            "deviceMap": [
                 "Audio2,1-left",
                 "Audio2,1-right"
             ],


### PR DESCRIPTION
… and add beta download for AirPods Pro 2. Fixes #136.