### PR TITLE
Add older release notes

### DIFF
--- a/osFiles/Software/Xcode/10A255.json
+++ b/osFiles/Software/Xcode/10A255.json
@@ -3,6 +3,7 @@
     "version": "10.0",
     "build": "10A255",
     "released": "2018-09-17",
+    "securityNotes": "https://support.apple.com/kb/HT209135",
     "deviceMap": [
         "Xcode"
     ],

--- a/osFiles/Software/Xcode/10E125.json
+++ b/osFiles/Software/Xcode/10E125.json
@@ -3,6 +3,7 @@
     "version": "10.2",
     "build": "10E125",
     "released": "2019-03-25",
+    "securityNotes": "https://support.apple.com/kb/HT209606",
     "deviceMap": [
         "Xcode"
     ],

--- a/osFiles/Software/Xcode/11A420a.json
+++ b/osFiles/Software/Xcode/11A420a.json
@@ -3,6 +3,7 @@
     "version": "11.0",
     "build": "11A420a",
     "released": "2019-09-20",
+    "securityNotes": "https://support.apple.com/kb/HT210609",
     "deviceMap": [
         "Xcode"
     ],

--- a/osFiles/Software/Xcode/11B52.json
+++ b/osFiles/Software/Xcode/11B52.json
@@ -3,6 +3,7 @@
     "version": "11.2",
     "build": "11B52",
     "released": "2019-10-31",
+    "securityNotes": "https://support.apple.com/kb/HT210729",
     "deviceMap": [
         "Xcode"
     ],

--- a/osFiles/Software/Xcode/11C29.json
+++ b/osFiles/Software/Xcode/11C29.json
@@ -3,6 +3,7 @@
     "version": "11.3",
     "build": "11C29",
     "released": "2019-12-10",
+    "securityNotes": "https://support.apple.com/kb/HT210796",
     "deviceMap": [
         "Xcode"
     ],

--- a/osFiles/Software/Xcode/9E145.json
+++ b/osFiles/Software/Xcode/9E145.json
@@ -3,6 +3,7 @@
     "version": "9.3",
     "build": "9E145",
     "released": "2018-03-29",
+    "securityNotes": "https://support.apple.com/kb/HT208699",
     "deviceMap": [
         "Xcode"
     ],

--- a/osFiles/Software/Xcode/9F2000.json
+++ b/osFiles/Software/Xcode/9F2000.json
@@ -3,6 +3,7 @@
     "version": "9.4.1",
     "build": "9F2000",
     "released": "2018-06-19",
+    "securityNotes": "https://support.apple.com/kb/HT208895",
     "deviceMap": [
         "Xcode"
     ],

--- a/osFiles/iOS/14x - 10.x/14A346.json
+++ b/osFiles/iOS/14x - 10.x/14A346.json
@@ -3,6 +3,8 @@
     "version": "10.0",
     "build": "14A346",
     "released": "2016-09-13",
+    "releaseNotes": "https://support.apple.com/HT208011#10",
+    "securityNotes": "https://support.apple.com/kb/HT207143",
     "preinstalled": [
         "iPhone9,1",
         "iPhone9,2",

--- a/osFiles/iOS/14x - 10.x/14A403.json
+++ b/osFiles/iOS/14x - 10.x/14A403.json
@@ -3,6 +3,8 @@
     "version": "10.0.1",
     "build": "14A403",
     "released": "2016-09-13",
+    "releaseNotes": "https://support.apple.com/HT208011#1001",
+    "securityNotes": "https://support.apple.com/kb/HT207145",
     "appledbWebImage": {
         "id": "ios10",
         "align": "left"

--- a/osFiles/iOS/14x - 10.x/14A456.json
+++ b/osFiles/iOS/14x - 10.x/14A456.json
@@ -3,6 +3,8 @@
     "version": "10.0.2",
     "build": "14A456",
     "released": "2016-09-23",
+    "releaseNotes": "https://support.apple.com/HT208011#1002",
+    "securityNotes": "https://support.apple.com/kb/HT207199",
     "appledbWebImage": {
         "id": "ios10",
         "align": "left"

--- a/osFiles/iOS/14x - 10.x/14A551.json
+++ b/osFiles/iOS/14x - 10.x/14A551.json
@@ -3,6 +3,8 @@
     "version": "10.0.3",
     "build": "14A551",
     "released": "2016-10-17",
+    "releaseNotes": "https://support.apple.com/HT208011#1003",
+    "securityNotes": "https://support.apple.com/kb/HT207263",
     "appledbWebImage": {
         "id": "ios10",
         "align": "left"

--- a/osFiles/iOS/14x - 10.x/14B100.json
+++ b/osFiles/iOS/14x - 10.x/14B100.json
@@ -3,6 +3,8 @@
     "version": "10.1.1",
     "build": "14B100",
     "released": "2016-10-31",
+    "releaseNotes": "https://support.apple.com/HT208011#1011",
+    "securityNotes": "https://support.apple.com/kb/HT207287",
     "appledbWebImage": {
         "id": "ios10",
         "align": "left"

--- a/osFiles/iOS/14x - 10.x/14B72c.json
+++ b/osFiles/iOS/14x - 10.x/14B72c.json
@@ -3,6 +3,8 @@
     "version": "10.1",
     "build": "14B72c",
     "released": "2016-10-24",
+    "releaseNotes": "https://support.apple.com/HT208011#101",
+    "securityNotes": "https://support.apple.com/kb/HT207271",
     "appledbWebImage": {
         "id": "ios10",
         "align": "left"

--- a/osFiles/iOS/14x - 10.x/14C92.json
+++ b/osFiles/iOS/14x - 10.x/14C92.json
@@ -3,6 +3,8 @@
     "version": "10.2",
     "build": "14C92",
     "released": "2016-12-12",
+    "releaseNotes": "https://support.apple.com/HT208011#102",
+    "securityNotes": "https://support.apple.com/kb/HT207422",
     "appledbWebImage": {
         "id": "ios10",
         "align": "left"

--- a/osFiles/iOS/14x - 10.x/14D27.json
+++ b/osFiles/iOS/14x - 10.x/14D27.json
@@ -3,6 +3,8 @@
     "version": "10.2.1",
     "build": "14D27",
     "released": "2017-01-23",
+    "releaseNotes": "https://support.apple.com/HT208011#1021",
+    "securityNotes": "https://support.apple.com/kb/HT207482",
     "appledbWebImage": {
         "id": "ios10",
         "align": "left"

--- a/osFiles/iOS/14x - 10.x/14E277.json
+++ b/osFiles/iOS/14x - 10.x/14E277.json
@@ -3,6 +3,8 @@
     "version": "10.3",
     "build": "14E277",
     "released": "2017-01-23",
+    "releaseNotes": "https://support.apple.com/HT208011#103",
+    "securityNotes": "https://support.apple.com/kb/HT207617",
     "appledbWebImage": {
         "id": "ios10",
         "align": "left"

--- a/osFiles/iOS/14x - 10.x/14E304.json
+++ b/osFiles/iOS/14x - 10.x/14E304.json
@@ -3,6 +3,8 @@
     "version": "10.3.1",
     "build": "14E304",
     "released": "2017-04-03",
+    "releaseNotes": "https://support.apple.com/HT208011#1031",
+    "securityNotes": "https://support.apple.com/kb/HT207688",
     "appledbWebImage": {
         "id": "ios10",
         "align": "left"

--- a/osFiles/iOS/14x - 10.x/14F89.json
+++ b/osFiles/iOS/14x - 10.x/14F89.json
@@ -3,6 +3,8 @@
     "version": "10.3.2",
     "build": "14F89",
     "released": "2017-05-15",
+    "releaseNotes": "https://support.apple.com/HT208011#1032",
+    "securityNotes": "https://support.apple.com/kb/HT207798",
     "appledbWebImage": {
         "id": "ios10",
         "align": "left"

--- a/osFiles/iOS/14x - 10.x/14F90.json
+++ b/osFiles/iOS/14x - 10.x/14F90.json
@@ -3,6 +3,8 @@
     "version": "10.3.2",
     "build": "14F90",
     "released": "2017-05-15",
+    "releaseNotes": "https://support.apple.com/HT208011#1032",
+    "securityNotes": "https://support.apple.com/kb/HT207798",
     "appledbWebImage": {
         "id": "ios10",
         "align": "left"

--- a/osFiles/iOS/14x - 10.x/14F91.json
+++ b/osFiles/iOS/14x - 10.x/14F91.json
@@ -3,6 +3,8 @@
     "version": "10.3.2",
     "build": "14F91",
     "released": "2017-05-15",
+    "releaseNotes": "https://support.apple.com/HT208011#1032",
+    "securityNotes": "https://support.apple.com/kb/HT207798",
     "appledbWebImage": {
         "id": "ios10",
         "align": "left"

--- a/osFiles/iOS/14x - 10.x/14G60.json
+++ b/osFiles/iOS/14x - 10.x/14G60.json
@@ -3,6 +3,8 @@
     "version": "10.3.3",
     "build": "14G60",
     "released": "2017-07-19",
+    "releaseNotes": "https://support.apple.com/HT208011#1033",
+    "securityNotes": "https://support.apple.com/kb/HT207923",
     "appledbWebImage": {
         "id": "ios10",
         "align": "left"

--- a/osFiles/iOS/14x - 10.x/14G61.json
+++ b/osFiles/iOS/14x - 10.x/14G61.json
@@ -2,7 +2,8 @@
     "osStr": "iOS",
     "version": "10.3.4",
     "build": "14G61",
-    "released": "2017-07-22",
+    "released": "2019-07-22",
+    "releaseNotes": "https://support.apple.com/HT208011#1034",
     "appledbWebImage": {
         "id": "ios10",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15A372.json
+++ b/osFiles/iOS/15x - 11.x/15A372.json
@@ -3,6 +3,8 @@
     "version": "11.0",
     "build": "15A372",
     "released": "2017-09-19",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#11",
+    "securityNotes": "https://support.apple.com/kb/HT208112",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15A402.json
+++ b/osFiles/iOS/15x - 11.x/15A402.json
@@ -3,6 +3,8 @@
     "version": "11.0.1",
     "build": "15A402",
     "released": "2017-09-26",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#1101",
+    "securityNotes": "https://support.apple.com/kb/HT208143",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15A403.json
+++ b/osFiles/iOS/15x - 11.x/15A403.json
@@ -3,6 +3,8 @@
     "version": "11.0.1",
     "build": "15A403",
     "released": "2017-09-26",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#1101",
+    "securityNotes": "https://support.apple.com/kb/HT208143",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15A421.json
+++ b/osFiles/iOS/15x - 11.x/15A421.json
@@ -3,6 +3,8 @@
     "version": "11.0.2",
     "build": "15A421",
     "released": "2017-10-03",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#1102",
+    "securityNotes": "https://support.apple.com/kb/HT208164",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15A432.json
+++ b/osFiles/iOS/15x - 11.x/15A432.json
@@ -3,6 +3,8 @@
     "version": "11.0.3",
     "build": "15A432",
     "released": "2017-10-11",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#1103",
+    "securityNotes": "https://support.apple.com/kb/HT208182",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15A8391.json
+++ b/osFiles/iOS/15x - 11.x/15A8391.json
@@ -3,6 +3,8 @@
     "version": "11.0.1",
     "build": "15A8391",
     "released": "2017-09-26",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#1101",
+    "securityNotes": "https://support.apple.com/kb/HT208143",
     "preinstalled": true,
     "appledbWebImage": {
         "id": "ios11",

--- a/osFiles/iOS/15x - 11.x/15B101.json
+++ b/osFiles/iOS/15x - 11.x/15B101.json
@@ -3,6 +3,8 @@
     "version": "11.1",
     "build": "15B101",
     "released": "2017-10-31",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#111",
+    "securityNotes": "https://support.apple.com/kb/HT208222",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15B150.json
+++ b/osFiles/iOS/15x - 11.x/15B150.json
@@ -3,6 +3,8 @@
     "version": "11.1.1",
     "build": "15B150",
     "released": "2017-11-09",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#1111",
+    "securityNotes": "https://support.apple.com/kb/HT208255",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15B202.json
+++ b/osFiles/iOS/15x - 11.x/15B202.json
@@ -3,6 +3,8 @@
     "version": "11.1.2",
     "build": "15B202",
     "released": "2017-11-16",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#1112",
+    "securityNotes": "https://support.apple.com/kb/HT208282",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15B93.json
+++ b/osFiles/iOS/15x - 11.x/15B93.json
@@ -3,6 +3,8 @@
     "version": "11.1",
     "build": "15B93",
     "released": "2017-10-31",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#111",
+    "securityNotes": "https://support.apple.com/kb/HT208222",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15C113.json
+++ b/osFiles/iOS/15x - 11.x/15C113.json
@@ -3,6 +3,8 @@
     "version": "11.2",
     "build": "15C113",
     "released": "2017-12-04",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#112",
+    "securityNotes": "https://support.apple.com/kb/HT208334",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15C114.json
+++ b/osFiles/iOS/15x - 11.x/15C114.json
@@ -3,6 +3,8 @@
     "version": "11.2",
     "build": "15C114",
     "released": "2017-12-02",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#112",
+    "securityNotes": "https://support.apple.com/kb/HT208334",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15C153.json
+++ b/osFiles/iOS/15x - 11.x/15C153.json
@@ -3,6 +3,8 @@
     "version": "11.2.1",
     "build": "15C153",
     "released": "2017-12-13",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#113",
+    "securityNotes": "https://support.apple.com/kb/HT208357",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15C202.json
+++ b/osFiles/iOS/15x - 11.x/15C202.json
@@ -3,6 +3,8 @@
     "version": "11.2.2",
     "build": "15C202",
     "released": "2018-01-08",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#1121",
+    "securityNotes": "https://support.apple.com/kb/HT208401",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15D100.json
+++ b/osFiles/iOS/15x - 11.x/15D100.json
@@ -3,6 +3,8 @@
     "version": "11.2.6",
     "build": "15D100",
     "released": "2018-02-19",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#1126",
+    "securityNotes": "https://support.apple.com/kb/HT208534",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15D60.json
+++ b/osFiles/iOS/15x - 11.x/15D60.json
@@ -3,6 +3,8 @@
     "version": "11.2.5",
     "build": "15D60",
     "released": "2018-01-23",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#1125",
+    "securityNotes": "https://support.apple.com/kb/HT208463",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15E216.json
+++ b/osFiles/iOS/15x - 11.x/15E216.json
@@ -3,6 +3,8 @@
     "version": "11.3",
     "build": "15E216",
     "released": "2018-03-29",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#113",
+    "securityNotes": "https://support.apple.com/kb/HT208693",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15E218.json
+++ b/osFiles/iOS/15x - 11.x/15E218.json
@@ -3,6 +3,8 @@
     "version": "11.3",
     "build": "15E218",
     "released": "2018-03-29",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#113",
+    "securityNotes": "https://support.apple.com/kb/HT208693",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15E302.json
+++ b/osFiles/iOS/15x - 11.x/15E302.json
@@ -3,6 +3,8 @@
     "version": "11.3.1",
     "build": "15E302",
     "released": "2018-04-24",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#1131",
+    "securityNotes": "https://support.apple.com/kb/HT208743",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15F79.json
+++ b/osFiles/iOS/15x - 11.x/15F79.json
@@ -3,6 +3,8 @@
     "version": "11.4",
     "build": "15F79",
     "released": "2018-05-29",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#114",
+    "securityNotes": "https://support.apple.com/kb/HT208848",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/iOS/15x - 11.x/15G77.json
+++ b/osFiles/iOS/15x - 11.x/15G77.json
@@ -3,6 +3,8 @@
     "version": "11.4.1",
     "build": "15G77",
     "released": "2018-07-09",
+    "releaseNotes": "https://support.apple.com/kb/HT208067#1141",
+    "securityNotes": "https://support.apple.com/kb/HT208938",
     "appledbWebImage": {
         "id": "ios11",
         "align": "left"

--- a/osFiles/macOS/17x - 10.13.x/17A365.json
+++ b/osFiles/macOS/17x - 10.13.x/17A365.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13",
     "build": "17A365",
-    "released": "2017-09-25"
+    "released": "2017-09-25",
+    "securityNotes": "https://support.apple.com/HT208144"
 }

--- a/osFiles/macOS/17x - 10.13.x/17A405.json
+++ b/osFiles/macOS/17x - 10.13.x/17A405.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13",
     "build": "17A405",
-    "released": "2017-10-05"
+    "released": "2017-10-05",
+    "securityNotes": "https://support.apple.com/HT208165"
 }

--- a/osFiles/macOS/17x - 10.13.x/17B1002.json
+++ b/osFiles/macOS/17x - 10.13.x/17B1002.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.1",
     "build": "17B1002",
-    "released": "2017-11-29"
+    "released": "2017-11-29",
+    "securityNotes": "https://support.apple.com/HT208315"
 }

--- a/osFiles/macOS/17x - 10.13.x/17B1003.json
+++ b/osFiles/macOS/17x - 10.13.x/17B1003.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.1",
     "build": "17B1003",
-    "released": "2017-11-29"
+    "released": "2017-11-29",
+    "securityNotes": "https://support.apple.com/HT208315"
 }

--- a/osFiles/macOS/17x - 10.13.x/17B48.json
+++ b/osFiles/macOS/17x - 10.13.x/17B48.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.1",
     "build": "17B48",
-    "released": "2017-10-31"
+    "released": "2017-10-31",
+    "securityNotes": "https://support.apple.com/HT208221"
 }

--- a/osFiles/macOS/17x - 10.13.x/17C205.json
+++ b/osFiles/macOS/17x - 10.13.x/17C205.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.2",
     "build": "17C205",
-    "released": "2018-01-08"
+    "released": "2018-01-08",
+    "securityNotes": "https://support.apple.com/HT208397"
 }

--- a/osFiles/macOS/17x - 10.13.x/17C2205.json
+++ b/osFiles/macOS/17x - 10.13.x/17C2205.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.2",
     "build": "17C2205",
-    "released": "2018-01-08"
+    "released": "2018-01-08",
+    "securityNotes": "https://support.apple.com/HT208397"
 }

--- a/osFiles/macOS/17x - 10.13.x/17C88.json
+++ b/osFiles/macOS/17x - 10.13.x/17C88.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.2",
     "build": "17C88",
-    "released": "2017-12-06"
+    "released": "2017-12-06",
+    "securityNotes": "https://support.apple.com/HT208331"
 }

--- a/osFiles/macOS/17x - 10.13.x/17C89.json
+++ b/osFiles/macOS/17x - 10.13.x/17C89.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.2",
     "build": "17C89",
-    "released": "2017-12-06"
+    "released": "2017-12-06",
+    "securityNotes": "https://support.apple.com/HT208331"
 }

--- a/osFiles/macOS/17x - 10.13.x/17D102.json
+++ b/osFiles/macOS/17x - 10.13.x/17D102.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.3",
     "build": "17D102",
-    "released": "2018-02-19"
+    "released": "2018-02-19",
+    "securityNotes": "https://support.apple.com/HT208535"
 }

--- a/osFiles/macOS/17x - 10.13.x/17D2047.json
+++ b/osFiles/macOS/17x - 10.13.x/17D2047.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.3",
     "build": "17D2047",
-    "released": "2018-01-23"
+    "released": "2018-01-23",
+    "securityNotes": "https://support.apple.com/HT208465"
 }

--- a/osFiles/macOS/17x - 10.13.x/17D2102.json
+++ b/osFiles/macOS/17x - 10.13.x/17D2102.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.3",
     "build": "17D2102",
-    "released": "2018-02-19"
+    "released": "2018-02-19",
+    "securityNotes": "https://support.apple.com/HT208535"
 }

--- a/osFiles/macOS/17x - 10.13.x/17D47.json
+++ b/osFiles/macOS/17x - 10.13.x/17D47.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.3",
     "build": "17D47",
-    "released": "2018-01-23"
+    "released": "2018-01-23",
+    "securityNotes": "https://support.apple.com/HT208465"
 }

--- a/osFiles/macOS/17x - 10.13.x/17E199.json
+++ b/osFiles/macOS/17x - 10.13.x/17E199.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.4",
     "build": "17E199",
-    "released": "2018-03-29"
+    "released": "2018-03-29",
+    "securityNotes": "https://support.apple.com/HT208692"
 }

--- a/osFiles/macOS/17x - 10.13.x/17E202.json
+++ b/osFiles/macOS/17x - 10.13.x/17E202.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.4",
     "build": "17E202",
-    "released": "2018-04-24"
+    "released": "2018-04-24",
+    "securityNotes": "https://support.apple.com/HT208742"
 }

--- a/osFiles/macOS/17x - 10.13.x/17F77.json
+++ b/osFiles/macOS/17x - 10.13.x/17F77.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.5",
     "build": "17F77",
-    "released": "2018-06-01"
+    "released": "2018-06-01",
+    "securityNotes": "https://support.apple.com/HT208849"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G10021.json
+++ b/osFiles/macOS/17x - 10.13.x/17G10021.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G10021",
-    "released": "2019-12-10"
+    "released": "2019-12-10",
+    "securityNotes": "https://support.apple.com/HT210788"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G11023.json
+++ b/osFiles/macOS/17x - 10.13.x/17G11023.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G11023",
-    "released": "2020-01-28"
+    "released": "2020-01-28",
+    "securityNotes": "https://support.apple.com/HT210919"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G12034.json
+++ b/osFiles/macOS/17x - 10.13.x/17G12034.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G12034",
-    "released": "2020-03-24"
+    "released": "2020-03-24",
+    "securityNotes": "https://support.apple.com/HT211100"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G13033.json
+++ b/osFiles/macOS/17x - 10.13.x/17G13033.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G13033",
-    "released": "2020-05-26"
+    "released": "2020-05-26",
+    "securityNotes": "https://support.apple.com/HT211170"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G13035.json
+++ b/osFiles/macOS/17x - 10.13.x/17G13035.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G13035",
-    "released": "2020-06-01"
+    "released": "2020-06-01",
+    "securityNotes": "https://support.apple.com/HT211215"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G14019.json
+++ b/osFiles/macOS/17x - 10.13.x/17G14019.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G14019",
-    "released": "2020-07-15"
+    "released": "2020-07-15",
+    "securityNotes": "https://support.apple.com/HT211289"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G14033.json
+++ b/osFiles/macOS/17x - 10.13.x/17G14033.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G14033",
-    "released": "2020-09-24"
+    "released": "2020-09-24",
+    "securityNotes": "https://support.apple.com/HT211849"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G14042.json
+++ b/osFiles/macOS/17x - 10.13.x/17G14042.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G14042",
-    "released": "2020-11-12"
+    "released": "2020-11-12",
+    "securityNotes": "https://support.apple.com/HT211946"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G2208.json
+++ b/osFiles/macOS/17x - 10.13.x/17G2208.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G2208",
-    "released": "2018-07-24"
+    "released": "2018-07-24",
+    "preinstalled": true
 }

--- a/osFiles/macOS/17x - 10.13.x/17G2307.json
+++ b/osFiles/macOS/17x - 10.13.x/17G2307.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G2307",
-    "released": "2018-08-28"
+    "released": "2018-08-28",
+    "securityNotes": "https://support.apple.com/HT209081"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G3025.json
+++ b/osFiles/macOS/17x - 10.13.x/17G3025.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G3025",
-    "released": "2018-10-30"
+    "released": "2018-10-30",
+    "securityNotes": "https://support.apple.com/HT209193"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G4015.json
+++ b/osFiles/macOS/17x - 10.13.x/17G4015.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G4015",
-    "released": "2018-12-05"
+    "released": "2018-12-05",
+    "securityNotes": "https://support.apple.com/HT209341"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G5019.json
+++ b/osFiles/macOS/17x - 10.13.x/17G5019.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G5019",
-    "released": "2019-01-22"
+    "released": "2019-01-22",
+    "securityNotes": "https://support.apple.com/HT209446"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G6029.json
+++ b/osFiles/macOS/17x - 10.13.x/17G6029.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G6029",
-    "released": "2019-03-25"
+    "released": "2019-03-25",
+    "securityNotes": "https://support.apple.com/HT209600"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G6030.json
+++ b/osFiles/macOS/17x - 10.13.x/17G6030.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G6030",
-    "released": "2019-03-29"
+    "released": "2019-03-29",
+    "securityNotes": "https://support.apple.com/HT209635"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G65.json
+++ b/osFiles/macOS/17x - 10.13.x/17G65.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G65",
-    "released": "2018-07-09"
+    "released": "2018-07-09",
+    "securityNotes": "https://support.apple.com/HT208937"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G7024.json
+++ b/osFiles/macOS/17x - 10.13.x/17G7024.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G7024",
-    "released": "2019-05-13"
+    "released": "2019-05-13",
+    "securityNotes": "https://support.apple.com/HT210119"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G8029.json
+++ b/osFiles/macOS/17x - 10.13.x/17G8029.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G8029",
-    "released": "2019-07-22"
+    "released": "2019-07-22",
+    "securityNotes": "https://support.apple.com/HT210348"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G8030.json
+++ b/osFiles/macOS/17x - 10.13.x/17G8030.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G8030",
-    "released": "2019-07-29"
+    "released": "2019-07-29",
+    "securityNotes": "https://support.apple.com/HT210348"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G8037.json
+++ b/osFiles/macOS/17x - 10.13.x/17G8037.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G8037",
-    "released": "2019-09-26"
+    "released": "2019-09-26",
+    "securityNotes": "https://support.apple.com/HT210589"
 }

--- a/osFiles/macOS/17x - 10.13.x/17G9016.json
+++ b/osFiles/macOS/17x - 10.13.x/17G9016.json
@@ -2,5 +2,6 @@
     "osStr": "macOS",
     "version": "10.13.6",
     "build": "17G9016",
-    "released": "2019-10-29"
+    "released": "2019-10-29",
+    "securityNotes": "https://support.apple.com/HT210722"
 }

--- a/osFiles/tvOS/12x - 7.x/12H847.json
+++ b/osFiles/tvOS/12x - 7.x/12H847.json
@@ -4,6 +4,7 @@
     "iosVersion": "8.4.2",
     "build": "12H847",
     "released": "2019-05-13",
+    "securityNotes": "https://support.apple.com/kb/HT210121",
     "deviceMap": [
         "AppleTV3,1",
         "AppleTV3,2"

--- a/osFiles/tvOS/14x - 10.x/14T330.json
+++ b/osFiles/tvOS/14x - 10.x/14T330.json
@@ -3,6 +3,7 @@
     "version": "10.0",
     "build": "14T330",
     "released": "2016-09-13",
+    "securityNotes": "https://support.apple.com/kb/HT207142",
     "deviceMap": [
         "AppleTV5,3"
     ],

--- a/osFiles/tvOS/14x - 10.x/14U593.json
+++ b/osFiles/tvOS/14x - 10.x/14U593.json
@@ -3,6 +3,7 @@
     "version": "10.1",
     "build": "14U593",
     "released": "2016-12-12",
+    "securityNotes": "https://support.apple.com/kb/HT207425",
     "deviceMap": [
         "AppleTV5,3"
     ],

--- a/osFiles/tvOS/14x - 10.x/14U71.json
+++ b/osFiles/tvOS/14x - 10.x/14U71.json
@@ -3,6 +3,7 @@
     "version": "10.0.1",
     "build": "14U71",
     "released": "2016-10-24",
+    "securityNotes": "https://support.apple.com/kb/HT207270",
     "deviceMap": [
         "AppleTV5,3"
     ],

--- a/osFiles/tvOS/14x - 10.x/14U712a.json
+++ b/osFiles/tvOS/14x - 10.x/14U712a.json
@@ -3,6 +3,7 @@
     "version": "10.1.1",
     "build": "14U712a",
     "released": "2017-01-23",
+    "securityNotes": "https://support.apple.com/kb/HT207485",
     "deviceMap": [
         "AppleTV5,3"
     ],

--- a/osFiles/tvOS/14x - 10.x/14W265.json
+++ b/osFiles/tvOS/14x - 10.x/14W265.json
@@ -3,6 +3,7 @@
     "version": "10.2",
     "build": "14W265",
     "released": "2017-03-27",
+    "securityNotes": "https://support.apple.com/kb/HT207601",
     "deviceMap": [
         "AppleTV5,3"
     ],

--- a/osFiles/tvOS/14x - 10.x/14W585a.json
+++ b/osFiles/tvOS/14x - 10.x/14W585a.json
@@ -3,6 +3,7 @@
     "version": "10.2.1",
     "build": "14W585a",
     "released": "2017-05-15",
+    "securityNotes": "https://support.apple.com/kb/HT207801",
     "deviceMap": [
         "AppleTV5,3"
     ],

--- a/osFiles/tvOS/14x - 10.x/14W756.json
+++ b/osFiles/tvOS/14x - 10.x/14W756.json
@@ -3,6 +3,7 @@
     "version": "10.2.2",
     "build": "14W756",
     "released": "2017-07-19",
+    "securityNotes": "https://support.apple.com/kb/HT207924",
     "deviceMap": [
         "AppleTV5,3"
     ],

--- a/osFiles/tvOS/15x - 11.x/15J381.json
+++ b/osFiles/tvOS/15x - 11.x/15J381.json
@@ -3,6 +3,8 @@
     "version": "11.0",
     "build": "15J381",
     "released": "2017-09-19",
+    "releaseNotes": "https://support.apple.com/HT207936",
+    "securityNotes": "https://support.apple.com/kb/HT208113",
     "deviceMap": [
         "AppleTV5,3",
         "AppleTV6,2"

--- a/osFiles/tvOS/15x - 11.x/15J582.json
+++ b/osFiles/tvOS/15x - 11.x/15J582.json
@@ -3,6 +3,8 @@
     "version": "11.1",
     "build": "15J582",
     "released": "2017-10-31",
+    "releaseNotes": "https://support.apple.com/HT207936",
+    "securityNotes": "https://support.apple.com/kb/HT208219",
     "deviceMap": [
         "AppleTV5,3",
         "AppleTV6,2"

--- a/osFiles/tvOS/15x - 11.x/15K106.json
+++ b/osFiles/tvOS/15x - 11.x/15K106.json
@@ -3,6 +3,8 @@
     "version": "11.2",
     "build": "15K106",
     "released": "2017-12-04",
+    "releaseNotes": "https://support.apple.com/HT207936",
+    "securityNotes": "https://support.apple.com/kb/HT208327",
     "deviceMap": [
         "AppleTV5,3",
         "AppleTV6,2"

--- a/osFiles/tvOS/15x - 11.x/15K152.json
+++ b/osFiles/tvOS/15x - 11.x/15K152.json
@@ -3,6 +3,8 @@
     "version": "11.2.1",
     "build": "15K152",
     "released": "2017-12-13",
+    "releaseNotes": "https://support.apple.com/HT207936",
+    "securityNotes": "https://support.apple.com/kb/HT208359",
     "deviceMap": [
         "AppleTV5,3",
         "AppleTV6,2"

--- a/osFiles/tvOS/15x - 11.x/15K552.json
+++ b/osFiles/tvOS/15x - 11.x/15K552.json
@@ -3,6 +3,8 @@
     "version": "11.2.5",
     "build": "15K552",
     "released": "2018-01-23",
+    "releaseNotes": "https://support.apple.com/HT207936",
+    "securityNotes": "https://support.apple.com/kb/HT208462",
     "deviceMap": [
         "AppleTV5,3",
         "AppleTV6,2"

--- a/osFiles/tvOS/15x - 11.x/15K600.json
+++ b/osFiles/tvOS/15x - 11.x/15K600.json
@@ -3,6 +3,8 @@
     "version": "11.2.6",
     "build": "15K600",
     "released": "2018-02-19",
+    "releaseNotes": "https://support.apple.com/HT207936",
+    "securityNotes": "https://support.apple.com/kb/HT208536",
     "deviceMap": [
         "AppleTV5,3",
         "AppleTV6,2"

--- a/osFiles/tvOS/15x - 11.x/15L211.json
+++ b/osFiles/tvOS/15x - 11.x/15L211.json
@@ -3,6 +3,8 @@
     "version": "11.3",
     "build": "15L211",
     "released": "2018-03-29",
+    "releaseNotes": "https://support.apple.com/HT207936",
+    "securityNotes": "https://support.apple.com/kb/HT208698",
     "deviceMap": [
         "AppleTV5,3",
         "AppleTV6,2"

--- a/osFiles/tvOS/15x - 11.x/15L577.json
+++ b/osFiles/tvOS/15x - 11.x/15L577.json
@@ -3,6 +3,8 @@
     "version": "11.4",
     "build": "15L577",
     "released": "2018-05-29",
+    "releaseNotes": "https://support.apple.com/HT207936",
+    "securityNotes": "https://support.apple.com/kb/HT208850",
     "deviceMap": [
         "AppleTV5,3",
         "AppleTV6,2"

--- a/osFiles/tvOS/15x - 11.x/15M73.json
+++ b/osFiles/tvOS/15x - 11.x/15M73.json
@@ -3,6 +3,8 @@
     "version": "11.4.1",
     "build": "15M73",
     "released": "2018-07-09",
+    "releaseNotes": "https://support.apple.com/HT207936",
+    "securityNotes": "https://support.apple.com/kb/HT208936",
     "deviceMap": [
         "AppleTV5,3",
         "AppleTV6,2"

--- a/osFiles/watchOS/14x - 3.x/14S326.json
+++ b/osFiles/watchOS/14x - 3.x/14S326.json
@@ -4,6 +4,8 @@
     "iosVersion": "10.0",
     "build": "14S326",
     "released": "2016-09-13",
+    "releaseNotes": "https://support.apple.com/kb/DL1894",
+    "securityNotes": "https://support.apple.com/kb/HT207141",
     "deviceMap": [
         "Watch1,1",
         "Watch1,2",

--- a/osFiles/watchOS/14x - 3.x/14S471.json
+++ b/osFiles/watchOS/14x - 3.x/14S471.json
@@ -4,6 +4,8 @@
     "iosVersion": "10.1",
     "build": "14S471",
     "released": "2016-10-24",
+    "releaseNotes": "https://support.apple.com/kb/DL1894",
+    "securityNotes": "https://support.apple.com/kb/HT207269",
     "deviceMap": [
         "Watch1,1",
         "Watch1,2",

--- a/osFiles/watchOS/14x - 3.x/14S883.json
+++ b/osFiles/watchOS/14x - 3.x/14S883.json
@@ -4,6 +4,7 @@
     "iosVersion": "10.2",
     "build": "14S883",
     "released": "2016-12-12",
+    "releaseNotes": "https://support.apple.com/kb/DL1894",
     "deviceMap": [
         "Watch1,1",
         "Watch1,2",

--- a/osFiles/watchOS/14x - 3.x/14S960.json
+++ b/osFiles/watchOS/14x - 3.x/14S960.json
@@ -4,6 +4,8 @@
     "iosVersion": "10.2.1",
     "build": "14S960",
     "released": "2017-01-23",
+    "releaseNotes": "https://support.apple.com/kb/DL1894",
+    "securityNotes": "https://support.apple.com/kb/HT207487",
     "deviceMap": [
         "Watch1,1",
         "Watch1,2",

--- a/osFiles/watchOS/14x - 3.x/14V249.json
+++ b/osFiles/watchOS/14x - 3.x/14V249.json
@@ -4,6 +4,8 @@
     "iosVersion": "10.3",
     "build": "14V249",
     "released": "2017-03-27",
+    "releaseNotes": "https://support.apple.com/kb/DL1894",
+    "securityNotes": "https://support.apple.com/kb/HT207602",
     "deviceMap": [
         "Watch1,1",
         "Watch1,2",

--- a/osFiles/watchOS/14x - 3.x/14V485.json
+++ b/osFiles/watchOS/14x - 3.x/14V485.json
@@ -4,6 +4,8 @@
     "iosVersion": "10.3.2",
     "build": "14V485",
     "released": "2017-05-15",
+    "releaseNotes": "https://support.apple.com/kb/DL1894",
+    "securityNotes": "https://support.apple.com/kb/HT207800",
     "deviceMap": [
         "Watch1,1",
         "Watch1,2",

--- a/osFiles/watchOS/14x - 3.x/14V753.json
+++ b/osFiles/watchOS/14x - 3.x/14V753.json
@@ -4,6 +4,8 @@
     "iosVersion": "10.3.3",
     "build": "14V753",
     "released": "2017-07-19",
+    "releaseNotes": "https://support.apple.com/kb/DL1894",
+    "securityNotes": "https://support.apple.com/kb/HT207925",
     "deviceMap": [
         "Watch1,1",
         "Watch1,2",

--- a/osFiles/watchOS/15x - 4.x/15R372.json
+++ b/osFiles/watchOS/15x - 4.x/15R372.json
@@ -4,6 +4,8 @@
     "iosVersion": "11.0",
     "build": "15R372",
     "released": "2017-09-19",
+    "releaseNotes": "https://support.apple.com/HT208071#4",
+    "securityNotes": "https://support.apple.com/HT208115",
     "deviceMap": [
         "Watch1,1",
         "Watch1,2",

--- a/osFiles/watchOS/15x - 4.x/15R654.json
+++ b/osFiles/watchOS/15x - 4.x/15R654.json
@@ -4,6 +4,8 @@
     "iosVersion": "11.0",
     "build": "15R654",
     "released": "2017-10-04",
+    "releaseNotes": "https://support.apple.com/HT208071#401",
+    "securityNotes": "https://support.apple.com/HT208163",
     "deviceMap": [
         "Watch1,1",
         "Watch1,2",

--- a/osFiles/watchOS/15x - 4.x/15R846.json
+++ b/osFiles/watchOS/15x - 4.x/15R846.json
@@ -4,6 +4,8 @@
     "iosVersion": "11.1",
     "build": "15R846",
     "released": "2017-10-31",
+    "releaseNotes": "https://support.apple.com/HT208071#41",
+    "securityNotes": "https://support.apple.com/HT208220",
     "deviceMap": [
         "Watch1,1",
         "Watch1,2",

--- a/osFiles/watchOS/15x - 4.x/15S102.json
+++ b/osFiles/watchOS/15x - 4.x/15S102.json
@@ -4,6 +4,8 @@
     "iosVersion": "11.2",
     "build": "15S102",
     "released": "2017-12-05",
+    "releaseNotes": "https://support.apple.com/HT208071#42",
+    "securityNotes": "https://support.apple.com/HT208325",
     "deviceMap": [
         "Watch1,1",
         "Watch1,2",

--- a/osFiles/watchOS/15x - 4.x/15S542.json
+++ b/osFiles/watchOS/15x - 4.x/15S542.json
@@ -4,6 +4,8 @@
     "iosVersion": "11.2.5",
     "build": "15S542",
     "released": "2018-01-23",
+    "releaseNotes": "https://support.apple.com/HT208071#422",
+    "securityNotes": "https://support.apple.com/HT208464",
     "deviceMap": [
         "Watch1,1",
         "Watch1,2",

--- a/osFiles/watchOS/15x - 4.x/15S600b.json
+++ b/osFiles/watchOS/15x - 4.x/15S600b.json
@@ -4,6 +4,8 @@
     "iosVersion": "11.2.6",
     "build": "15S600b",
     "released": "2018-02-19",
+    "releaseNotes": "https://support.apple.com/HT208071#423",
+    "securityNotes": "https://support.apple.com/HT208537",
     "deviceMap": [
         "Watch1,1",
         "Watch1,2",

--- a/osFiles/watchOS/15x - 4.x/15T212.json
+++ b/osFiles/watchOS/15x - 4.x/15T212.json
@@ -4,6 +4,8 @@
     "iosVersion": "11.3",
     "build": "15T212",
     "released": "2018-03-29",
+    "releaseNotes": "https://support.apple.com/HT208071#43",
+    "securityNotes": "https://support.apple.com/HT208696",
     "deviceMap": [
         "Watch1,1",
         "Watch1,2",

--- a/osFiles/watchOS/15x - 4.x/15T567.json
+++ b/osFiles/watchOS/15x - 4.x/15T567.json
@@ -4,6 +4,8 @@
     "iosVersion": "11.4",
     "build": "15T567",
     "released": "2018-05-29",
+    "releaseNotes": "https://support.apple.com/HT208071#431",
+    "securityNotes": "https://support.apple.com/HT208851",
     "deviceMap": [
         "Watch1,1",
         "Watch1,2",

--- a/osFiles/watchOS/15x - 4.x/15U70.json
+++ b/osFiles/watchOS/15x - 4.x/15U70.json
@@ -4,6 +4,8 @@
     "iosVersion": "11.4.1",
     "build": "15U70",
     "released": "2018-07-09",
+    "releaseNotes": "https://support.apple.com/HT208071#432",
+    "securityNotes": "https://support.apple.com/HT208935",
     "deviceMap": [
         "Watch1,1",
         "Watch1,2",


### PR DESCRIPTION
Includes

- iOS 10&11
- tvOS 10&11
- watchOS 3&4
- macOS High Sierra

At this point, it's painful to get older documentation from Apple, not sure if/when I'll be able to keep digging