### PR TITLE
Fix wrong data type for beta in iOS SDK 10.1 beta 4

### DIFF
--- a/osFiles/sdks/iOS/14B72.json
+++ b/osFiles/sdks/iOS/14B72.json
@@ -5,7 +5,7 @@
     "uniqueBuild": "14B72-SDK",
     "released": "2016-10-24",
     "sdk": true,
-    "beta": "true",
+    "beta": true,
     "deviceMap": [
         "iOS SDK"
     ],


### PR DESCRIPTION
The data type is bool, not string.