### PR TITLE
Add known bridgeOS pkg links

### DIFF
--- a/osFiles/bridgeOS/15x/15P254.json
+++ b/osFiles/bridgeOS/15x/15P254.json
@@ -5,5 +5,20 @@
     "preinstalled": true,
     "deviceMap": [
         "iBridge2,1"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/15/02/091-48216/w9o9lgv1kmq13yy7px7atr9hi90pvfk8vq/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 145411411
+        }
     ]
 }

--- a/osFiles/bridgeOS/15x/15P2542.json
+++ b/osFiles/bridgeOS/15x/15P2542.json
@@ -23,6 +23,19 @@
                 "sha1": "2b9502b62307c7e43481559ed4f03175b12e14c2"
             },
             "size": 190634516
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/32/49/091-62778/rjfmsqro4md892byscii8qotnp8h5k6w7i/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 121654617
         }
     ]
 }

--- a/osFiles/bridgeOS/15x/15P5064.json
+++ b/osFiles/bridgeOS/15x/15P5064.json
@@ -22,6 +22,19 @@
                 "sha1": "9e2c3737cdf32739ed134aa53e0b8fd64cac1b02"
             },
             "size": 213407235
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/53/61/091-86776/ob7458kt66dzeli272uwnvvggtlrxbyyoy/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 133635415
         }
     ]
 }

--- a/osFiles/bridgeOS/15x/15P56045b.json
+++ b/osFiles/bridgeOS/15x/15P56045b.json
@@ -6,5 +6,20 @@
     "beta": true,
     "deviceMap": [
         "iBridge2,1"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/33/44/091-89902/ftsfsavdshjjk648nwwd5602lj8i07fsfg/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 133696853
+        }
     ]
 }

--- a/osFiles/bridgeOS/15x/15P56053a.json
+++ b/osFiles/bridgeOS/15x/15P56053a.json
@@ -6,5 +6,20 @@
     "beta": true,
     "deviceMap": [
         "iBridge2,1"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/05/48/091-90758/e0jxbp1llpzgvl30nt746mbw24exkm0sn9/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 133688659
+        }
     ]
 }

--- a/osFiles/bridgeOS/15x/15P56058b.json
+++ b/osFiles/bridgeOS/15x/15P56058b.json
@@ -6,5 +6,20 @@
     "beta": true,
     "deviceMap": [
         "iBridge2,1"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/52/33/091-94192/7vjbq0d26xsygd8nqi5d257r32r8hahhjn/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 133664090
+        }
     ]
 }

--- a/osFiles/bridgeOS/15x/15P6059.json
+++ b/osFiles/bridgeOS/15x/15P6059.json
@@ -22,6 +22,19 @@
                 "sha1": "24d06b99f42193999ff76c1408cc7c89d7ba682b"
             },
             "size": 213302880
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/37/29/091-94323/5kjowjpet7hwilvfph9hyaipuakw0eocqg/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 133750107
         }
     ]
 }

--- a/osFiles/bridgeOS/15x/15P6703.json
+++ b/osFiles/bridgeOS/15x/15P6703.json
@@ -6,5 +6,21 @@
     "deviceMap": [
         "iBridge2,3",
         "iBridge2,4"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,3",
+                "iBridge2,4"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/51/38/091-97100/6ut6wurjkj32w5e1yfst9dwrijrcp2utgf/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 193228117
+        }
     ]
 }

--- a/osFiles/bridgeOS/15x/15P6805.json
+++ b/osFiles/bridgeOS/15x/15P6805.json
@@ -6,5 +6,21 @@
     "deviceMap": [
         "iBridge2,3",
         "iBridge2,4"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,3",
+                "iBridge2,4"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/11/08/091-97108/4ccec0h09qkuxwpiec27bd9j458mr0wcwu/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 193228101
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P1065.json
+++ b/osFiles/bridgeOS/16x/16P1065.json
@@ -8,5 +8,23 @@
         "iBridge2,3",
         "iBridge2,4",
         "iBridge2,5"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/26/39/041-18034/52oncejd7b11demet5fnvgtgofcp9kpxt0/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 284257576
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P1582.json
+++ b/osFiles/bridgeOS/16x/16P1582.json
@@ -5,5 +5,20 @@
     "released": "2018-11-05",
     "deviceMap": [
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/22/16/041-18149/qs6k03b70plmmoa4hkp170ois16091arj5/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 324680997
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P2088.json
+++ b/osFiles/bridgeOS/16x/16P2088.json
@@ -6,5 +6,20 @@
     "preinstalled": true,
     "deviceMap": [
         "iBridge2,7"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,7"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/40/62/041-06731/dp933ce3wmscy2egyy41c6t1fjizvoou3e/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 324042026
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P2542.json
+++ b/osFiles/bridgeOS/16x/16P2542.json
@@ -17,7 +17,10 @@
             "deviceMap": [
                 "iBridge2,1",
                 "iBridge2,3",
-                "iBridge2,4"
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
             ],
             "links": [
                 {
@@ -29,6 +32,24 @@
                 "sha1": "5bab53287299208012653700be17f79ecc95b806"
             },
             "size": 422439182
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/24/48/041-19986/xe4mfw1fye417g99eojllgliotgpfbhk3q/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 324013353
         }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P3133.json
+++ b/osFiles/bridgeOS/16x/16P3133.json
@@ -10,5 +10,43 @@
         "iBridge2,5",
         "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/28/02/041-31307/xvibxlykpmbsmi3novwdlppa7vi2cpma86/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 324013351
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/14/44/041-38918/u7u90818af1bwb4gilp1qkyzrl2nq5p48k/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 324013359
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P375.json
+++ b/osFiles/bridgeOS/16x/16P375.json
@@ -34,6 +34,24 @@
                 "sha1": "ab720f8fa8d9f8a9dc9dc87011607b1e0c95c741"
             },
             "size": 346959013
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/48/38/041-08711/39fme90oy4xz7sc1is187ujxq4jsvpi6jg/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 254012710
         }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P4507.json
+++ b/osFiles/bridgeOS/16x/16P4507.json
@@ -36,6 +36,24 @@
                 "md5": "7490332fb40e09bbb56031945bad8377"
             },
             "size": 424437058
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/60/62/041-56509/kipv5wb6d6mpvox85v3q35lzygienwrtac/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 323816747
         }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P50315f.json
+++ b/osFiles/bridgeOS/16x/16P50315f.json
@@ -6,5 +6,20 @@
     "beta": true,
     "deviceMap": [
         "iBridge2,1"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/52/52/091-90522/97nckwb6e31pvtd0xmjrgecdolwdn8ht24/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 205724981
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P50315h.json
+++ b/osFiles/bridgeOS/16x/16P50315h.json
@@ -6,5 +6,20 @@
     "beta": true,
     "deviceMap": [
         "iBridge2,1"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/55/35/091-92944/bt848w4xktreqqrpmy9lez56fjngvcf3rx/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 205745457
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P50325c.json
+++ b/osFiles/bridgeOS/16x/16P50325c.json
@@ -6,5 +6,33 @@
     "beta": true,
     "deviceMap": [
         "iBridge2,1"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/39/26/091-94339/dmbuynisbaoj0tzk2or6buirs85ds2lqn3/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 191114554
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/07/58/091-94202/v8f82b00bj6vzsgrourophublghu5d0vr6/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 191114550
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P50334e.json
+++ b/osFiles/bridgeOS/16x/16P50334e.json
@@ -8,5 +8,22 @@
         "iBridge2,1",
         "iBridge2,3",
         "iBridge2,4"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/37/45/091-95250/mpn13iveryomem7crpiy8ua0r8uqjpmdbv/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 251333943
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P50345e.json
+++ b/osFiles/bridgeOS/16x/16P50345e.json
@@ -8,5 +8,22 @@
         "iBridge2,1",
         "iBridge2,3",
         "iBridge2,4"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/58/23/091-95711/cw0i6wrccimbqcs84n21eexsq0bmshuljz/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 252833079
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P50351c.json
+++ b/osFiles/bridgeOS/16x/16P50351c.json
@@ -8,5 +8,22 @@
         "iBridge2,1",
         "iBridge2,3",
         "iBridge2,4"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/58/29/091-98045/s6nfxic6kif32dc0dt3mpshn36urx7jweo/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 252816692
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P50361a.json
+++ b/osFiles/bridgeOS/16x/16P50361a.json
@@ -8,5 +8,22 @@
         "iBridge2,1",
         "iBridge2,3",
         "iBridge2,4"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/21/10/091-99490/4pnr173izolme8ljhy1prsx729f8hw7p3b/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 253222179
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P50366a.json
+++ b/osFiles/bridgeOS/16x/16P50366a.json
@@ -8,5 +8,22 @@
         "iBridge2,1",
         "iBridge2,3",
         "iBridge2,4"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/32/07/041-00566/t6xowl0yvvxx1cl2vozuvkhe1wxwp33nhy/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 253242660
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P50371a.json
+++ b/osFiles/bridgeOS/16x/16P50371a.json
@@ -8,5 +8,22 @@
         "iBridge2,1",
         "iBridge2,3",
         "iBridge2,4"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/48/39/041-01260/enm13ot4ohtcnq7shgghrlf0ypg7gujqek/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 253189411
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P50374a.json
+++ b/osFiles/bridgeOS/16x/16P50374a.json
@@ -8,5 +8,22 @@
         "iBridge2,1",
         "iBridge2,3",
         "iBridge2,4"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/06/61/041-03374/geg2rxwczswve5ojidk58qvt7grpmnlx9l/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 253197608
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P51061a.json
+++ b/osFiles/bridgeOS/16x/16P51061a.json
@@ -8,5 +8,22 @@
         "iBridge2,1",
         "iBridge2,3",
         "iBridge2,4"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/47/04/041-12559/0uwpvlvl9qqftvyhul2eir6oiyndzx2jms/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 254393636
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P5125.json
+++ b/osFiles/bridgeOS/16x/16P5125.json
@@ -36,6 +36,24 @@
                 "md5": "b35413e812707117e424578322f0729b"
             },
             "size": 429179381
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/19/55/041-59915/pu8bmyppo1ddeuf1b3oc4mtsc8scl6fogh/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 327028014
         }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P5200.json
+++ b/osFiles/bridgeOS/16x/16P5200.json
@@ -36,6 +36,24 @@
                 "md5": "0d3e4d7dff296f287cabb321750a0b68"
             },
             "size": 429526380
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/14/30/041-64749/obhzky1l7pgsc6pyhl5jjtpw846dok6lm4/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 326896936
         }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P52529a.json
+++ b/osFiles/bridgeOS/16x/16P52529a.json
@@ -9,6 +9,45 @@
         "iBridge2,3",
         "iBridge2,4",
         "iBridge2,5",
+        "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/11/28/041-19024/vh3vv0zqnu8c96lcbhog5f70x4ekpyzwhv/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 324472099
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/10/56/041-18985/wh0p0ythm7h7s50pd2fds1bxq3kgt4tp6n/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 324472103
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P52534b.json
+++ b/osFiles/bridgeOS/16x/16P52534b.json
@@ -9,6 +9,27 @@
         "iBridge2,3",
         "iBridge2,4",
         "iBridge2,5",
+        "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/22/57/041-19749/yu5f4mesh4sd1uecl82ctajrjdauju4g27/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 324209961
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P52540a.json
+++ b/osFiles/bridgeOS/16x/16P52540a.json
@@ -11,5 +11,43 @@
         "iBridge2,5",
         "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/17/29/041-24617/hdodx9ze4j4gkxsozxdtmd5ppeuivguuy3/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 323947813
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/22/41/041-25636/mw0ttqc350yaoi4tll06518l6jymicvbt0/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 323947821
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P52541a.json
+++ b/osFiles/bridgeOS/16x/16P52541a.json
@@ -11,5 +11,25 @@
         "iBridge2,5",
         "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/49/31/041-25813/nep0pzqy8oqnshkbrnshd88zf4akzjq6wn/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 323947819
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P53118a.json
+++ b/osFiles/bridgeOS/16x/16P53118a.json
@@ -11,5 +11,25 @@
         "iBridge2,5",
         "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/52/53/041-26481/tfj12qov1ro68dkws1r21hvnrbfijxze4o/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 324013353
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P53129a.json
+++ b/osFiles/bridgeOS/16x/16P53129a.json
@@ -11,5 +11,25 @@
         "iBridge2,5",
         "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/54/44/041-27168/bos17gl6yde4ovmu498813lruay9yoxucg/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 324078882
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P53132a.json
+++ b/osFiles/bridgeOS/16x/16P53132a.json
@@ -11,5 +11,43 @@
         "iBridge2,5",
         "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/16/21/041-30441/f2rm5sxe4501pfj6liy0fbgqkmk8uwi3s7/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 324013353
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/63/27/041-29844/81rst7t6zpmddjtg8jlsds4hna0q67kvok/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 324013352
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P54075e.json
+++ b/osFiles/bridgeOS/16x/16P54075e.json
@@ -11,5 +11,25 @@
         "iBridge2,5",
         "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/45/11/041-31763/tvvifvvzdvfcr0j7un899m3oochb19bkex/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 323095847
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P54085b.json
+++ b/osFiles/bridgeOS/16x/16P54085b.json
@@ -11,5 +11,25 @@
         "iBridge2,5",
         "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/51/31/041-34272/un1r0eer2i6zm0dbpwft5nx14179gicwdw/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 323030314
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P54095d.json
+++ b/osFiles/bridgeOS/16x/16P54095d.json
@@ -11,5 +11,25 @@
         "iBridge2,5",
         "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/36/40/041-39675/qz130l1ht2bvjh8p9s81f2acl1oeewm0b8/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 323882279
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P54106c.json
+++ b/osFiles/bridgeOS/16x/16P54106c.json
@@ -11,5 +11,43 @@
         "iBridge2,5",
         "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/30/35/041-44770/vmq2v9jgovwrmpi5dgzhzd288uqdkee6py/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 323816742
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/25/22/041-40591/3kv1ep5b4p950ogdr2uit0tfyag73qhead/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 323816745
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P54505a.json
+++ b/osFiles/bridgeOS/16x/16P54505a.json
@@ -11,5 +11,25 @@
         "iBridge2,5",
         "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/45/30/041-46943/x2hpvtnf7b4g92wggtyinrk45r4r5o9y36/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 323816743
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P54506a.json
+++ b/osFiles/bridgeOS/16x/16P54506a.json
@@ -11,5 +11,61 @@
         "iBridge2,5",
         "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/06/42/041-48433/cppgv492gm8vkb5700kv7sz4gux55es6rv/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 323882278
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/27/49/041-47687/zs0fzn1a13ygzkqdm223qa1u0dz9b0hckj/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 323882282
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/43/18/041-88793/mv00e001cvq03ygn8xgor70ky9bld0dd5k/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 323892543
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P55107b.json
+++ b/osFiles/bridgeOS/16x/16P55107b.json
@@ -11,5 +11,43 @@
         "iBridge2,5",
         "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/52/05/041-55633/92elpoze024zqbd1zbkr8w7j4oh4ebh9ky/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 326569256
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/06/14/041-54720/4zvpk55d5na20x8jzl8k48tb8s7eq45lbc/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 326569252
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P55117a.json
+++ b/osFiles/bridgeOS/16x/16P55117a.json
@@ -11,5 +11,25 @@
         "iBridge2,5",
         "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/10/19/041-56262/b4aftnrolu2bmacys5b0lfkii578zxau56/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 326569258
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P55123a.json
+++ b/osFiles/bridgeOS/16x/16P55123a.json
@@ -11,5 +11,25 @@
         "iBridge2,5",
         "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/29/02/041-57566/rzkptoo73rvfizdcm3i6fbjohswjq9jiwa/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 326962477
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P55124a.json
+++ b/osFiles/bridgeOS/16x/16P55124a.json
@@ -11,5 +11,25 @@
         "iBridge2,5",
         "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/10/08/041-60493/o9898ko0riil3n7e5bq82r9ktl5es6un86/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 326962465
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P56529b.json
+++ b/osFiles/bridgeOS/16x/16P56529b.json
@@ -1,6 +1,6 @@
 {
     "osStr": "bridgeOS",
-    "version": "3.5 beta",
+    "version": "3.6 beta",
     "build": "16P56529b",
     "released": "2019-05-15",
     "beta": true,

--- a/osFiles/bridgeOS/16x/16P56548b.json
+++ b/osFiles/bridgeOS/16x/16P56548b.json
@@ -1,6 +1,6 @@
 {
     "osStr": "bridgeOS",
-    "version": "3.5 beta 2",
+    "version": "3.6 beta 2",
     "build": "16P56548b",
     "released": "2019-06-11",
     "beta": true,

--- a/osFiles/bridgeOS/16x/16P56548b.json
+++ b/osFiles/bridgeOS/16x/16P56548b.json
@@ -11,5 +11,43 @@
         "iBridge2,5",
         "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/50/44/041-70540/ilzbhm91py0qx4iztuizpormcc3iddf0a8/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 326241578
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/35/24/041-73140/bnujnqjcquojijkd5xbwae05qk1ufplu3j/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 326241577
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P56558a.json
+++ b/osFiles/bridgeOS/16x/16P56558a.json
@@ -1,6 +1,6 @@
 {
     "osStr": "bridgeOS",
-    "version": "3.5 beta 3",
+    "version": "3.6 beta 3",
     "build": "16P56558a",
     "released": "2019-06-24",
     "beta": true,

--- a/osFiles/bridgeOS/16x/16P56558a.json
+++ b/osFiles/bridgeOS/16x/16P56558a.json
@@ -11,5 +11,25 @@
         "iBridge2,5",
         "iBridge2,7",
         "iBridge2,8"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/01/54/041-74102/i6wk3rtxrh837itga0898021482ifz60b7/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 326307108
+        }
     ]
 }

--- a/osFiles/bridgeOS/16x/16P56566a.json
+++ b/osFiles/bridgeOS/16x/16P56566a.json
@@ -1,6 +1,6 @@
 {
     "osStr": "bridgeOS",
-    "version": "3.5 beta 4",
+    "version": "3.6 beta 4",
     "build": "16P56566a",
     "released": "2019-07-09",
     "beta": true,

--- a/osFiles/bridgeOS/16x/16P56567a.json
+++ b/osFiles/bridgeOS/16x/16P56567a.json
@@ -1,6 +1,6 @@
 {
     "osStr": "bridgeOS",
-    "version": "3.5 beta 5",
+    "version": "3.6 beta 5",
     "build": "16P56567a",
     "released": "2019-07-15",
     "beta": true,

--- a/osFiles/bridgeOS/16x/16P6568.json
+++ b/osFiles/bridgeOS/16x/16P6568.json
@@ -1,6 +1,6 @@
 {
     "osStr": "bridgeOS",
-    "version": "3.5",
+    "version": "3.6",
     "build": "16P6568",
     "released": "2019-07-22",
     "deviceMap": [

--- a/osFiles/bridgeOS/16x/16P6571.json
+++ b/osFiles/bridgeOS/16x/16P6571.json
@@ -1,6 +1,6 @@
 {
     "osStr": "bridgeOS",
-    "version": "3.5",
+    "version": "3.6",
     "build": "16P6571",
     "released": "2019-08-26",
     "deviceMap": [
@@ -12,5 +12,67 @@
         "iBridge2,8",
         "iBridge2,10",
         "iBridge2,12"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/46/16/061-41416-A_A39E5RVSTF/4wznyj70tain6lelstmo77vy3bzqnzsyxn/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 366097726
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/61/32/061-06472/yc9up6zm2xm3qyed7xfsn19fdq1l5931mf/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 366087463
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/28/40/061-21552-A_XNTVINTKTJ/8wymogbyt0c5kdu7l94426djhmtdyqkcmc/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 366087469
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P2551.json
+++ b/osFiles/bridgeOS/17x/17P2551.json
@@ -44,6 +44,28 @@
                 "md5": "48e0bcc3fd54ee68677bde2b2dbea641"
             },
             "size": 562936361
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/23/31/061-10703-A_896PTRU0UG/zol31h2nx9c5zsbo81m9ovt7pz5z0wxah9/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 448270589
         }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P3050.json
+++ b/osFiles/bridgeOS/17x/17P3050.json
@@ -44,6 +44,28 @@
                 "md5": "699dcfb88d89748d3564722564114bcc"
             },
             "size": 564315480
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/10/59/061-62855-A_9FRONAHK6M/miimjb56cvm8gsbod0uhob65dczhrckdfp/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 449515770
         }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P3561.json
+++ b/osFiles/bridgeOS/17x/17P3561.json
@@ -3,14 +3,36 @@
     "version": "4.3",
     "build": "17P3561",
     "released": "2020-03-18",
-    "preinstalled": true,
+    "preinstalled": [
+        "iBridge2,15"
+    ],
     "deviceMap": [
+        "iBridge2,1",
+        "iBridge2,3",
+        "iBridge2,4",
+        "iBridge2,5",
+        "iBridge2,6",
+        "iBridge2,7",
+        "iBridge2,8",
+        "iBridge2,10",
+        "iBridge2,12",
+        "iBridge2,14",
         "iBridge2,15"
     ],
     "sources": [
         {
             "type": "ipsw",
             "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
                 "iBridge2,15"
             ],
             "links": [

--- a/osFiles/bridgeOS/17x/17P4263.json
+++ b/osFiles/bridgeOS/17x/17P4263.json
@@ -48,6 +48,30 @@
                 "md5": "408a89a4e2a930315433407616bb6f58"
             },
             "size": 490618628
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/34/57/061-90689-A_7H99440DJG/wiyslfr6vk0yas1o290db8h3ou4tcfe6ut/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 371134713
         }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P4281.json
+++ b/osFiles/bridgeOS/17x/17P4281.json
@@ -48,6 +48,30 @@
                 "md5": "8870cba7476f6a1b46af221a58fc98ed"
             },
             "size": 490621483
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/33/01/061-96009-A_CWDJNM7GRX/2aws0nq6p0dgfmv6smfzw40jl81xil32th/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 371134713
         }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P4538.json
+++ b/osFiles/bridgeOS/17x/17P4538.json
@@ -7,6 +7,19 @@
         "iBridge2,21"
     ],
     "deviceMap": [
+        "iBridge2,1",
+        "iBridge2,3",
+        "iBridge2,4",
+        "iBridge2,5",
+        "iBridge2,6",
+        "iBridge2,7",
+        "iBridge2,8",
+        "iBridge2,10",
+        "iBridge2,11",
+        "iBridge2,12",
+        "iBridge2,13",
+        "iBridge2,14",
+        "iBridge2,15",
         "iBridge2,16",
         "iBridge2,21"
     ],
@@ -14,6 +27,19 @@
         {
             "type": "ipsw",
             "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
                 "iBridge2,16",
                 "iBridge2,21"
             ],
@@ -31,6 +57,33 @@
                 "md5": "ae0dc7a944a3efd3774f994d8f434662"
             },
             "size": 546167295
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,21"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/04/36/001-04547/xrjvgfu5pza6khwdkq8s5u6rrgw3yov0wr/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 419696893
         }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P50507f.json
+++ b/osFiles/bridgeOS/17x/17P50507f.json
@@ -12,5 +12,26 @@
         "iBridge2,7",
         "iBridge2,8",
         "iBridge2,10"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/56/37/041-85008/ur6c1u2sgs9buh5vh3qj2mrhz6v1yox0uo/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 426315081
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P50531d.json
+++ b/osFiles/bridgeOS/17x/17P50531d.json
@@ -13,5 +13,27 @@
         "iBridge2,8",
         "iBridge2,10",
         "iBridge2,12"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/54/38/061-00577/zy33gxsu569hbdxulsgq3r71fp3vq19o7p/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 426904900
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P50541b.json
+++ b/osFiles/bridgeOS/17x/17P50541b.json
@@ -13,5 +13,27 @@
         "iBridge2,8",
         "iBridge2,10",
         "iBridge2,12"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/39/25/061-02961/ch4ayblbmk8hg4ei8ej30yanmvdnz8uc9f/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 427691339
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P50553c.json
+++ b/osFiles/bridgeOS/17x/17P50553c.json
@@ -13,5 +13,27 @@
         "iBridge2,8",
         "iBridge2,10",
         "iBridge2,12"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/59/33/061-11430-A_D5AWBV1A7J/4stf485ct6ir9i8a1j4yj9bqm8f46gcs4v/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 427035976
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P50566a.json
+++ b/osFiles/bridgeOS/17x/17P50566a.json
@@ -13,5 +13,27 @@
         "iBridge2,8",
         "iBridge2,10",
         "iBridge2,12"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/45/54/061-21523-A_HW721BAHVT/obozxq1pulraz5c1w2iz5da0mdxtj3flk3/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 427167045
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P50569a.json
+++ b/osFiles/bridgeOS/17x/17P50569a.json
@@ -13,5 +13,27 @@
         "iBridge2,8",
         "iBridge2,10",
         "iBridge2,12"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/00/31/061-24999-A_JK0USJRUGF/xn37pieb9de83qwhgpdk3xdjum11sz9qgw/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 427167994
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P50571a.json
+++ b/osFiles/bridgeOS/17x/17P50571a.json
@@ -13,5 +13,27 @@
         "iBridge2,8",
         "iBridge2,10",
         "iBridge2,12"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/46/05/061-26773-A_YQTYFRL3RV/agkq647rd463ksx4xwafvy666i4lopsg13/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 427102456
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P51068f.json
+++ b/osFiles/bridgeOS/17x/17P51068f.json
@@ -14,5 +14,28 @@
         "iBridge2,8",
         "iBridge2,10",
         "iBridge2,12"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/04/23/061-30495-A_38RTA7N6QS/dje2kwe4c5zqm9y7dx5dclvc3ze61j7krc/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 414847226
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P5290.json
+++ b/osFiles/bridgeOS/17x/17P5290.json
@@ -52,6 +52,32 @@
                 "md5": "0b4cc82968d6b2ab0bff7ea10e62b5b4"
             },
             "size": 521484100
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,21"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/17/61/061-70034-A_LNARBRLUH1/vaecnvbo246sslk3diorye8fmhhoq01yoh/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 391713016
         }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P5300.json
+++ b/osFiles/bridgeOS/17x/17P5300.json
@@ -52,6 +52,32 @@
                 "md5": "499082b3c6df1eb1e1b6320c95b23919"
             },
             "size": 521486223
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,21"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/52/12/001-12349-A_L6LBHPB47W/9kcix5h1eyqjtgazt2qqpt9bb8hb4eymdh/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 391713023
         }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P53025a.json
+++ b/osFiles/bridgeOS/17x/17P53025a.json
@@ -15,5 +15,51 @@
         "iBridge2,10",
         "iBridge2,12",
         "iBridge2,14"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/42/20/061-61633-A_ZWY5Q02OYX/d52u394f23kwssz5n4edeo9a3n8gm26930/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 450302206
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/57/49/061-63224-A_TRVZXF0GIH/1q60nkixttjpwadqod2dce1oyvrninqznt/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 450302205
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P53038c.json
+++ b/osFiles/bridgeOS/17x/17P53038c.json
@@ -15,5 +15,29 @@
         "iBridge2,10",
         "iBridge2,12",
         "iBridge2,14"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/27/13/061-67738-A_P8PBW4VD7R/y9u997xi0ts0lwrjvx9po1fevljrc8l1ne/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 449319169
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P53049a.json
+++ b/osFiles/bridgeOS/17x/17P53049a.json
@@ -15,5 +15,29 @@
         "iBridge2,10",
         "iBridge2,12",
         "iBridge2,14"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/59/11/061-70203-A_WW7B4WVCM9/mxvuwnb6t1yo1ti1e39y23kv2mqgfxu4da/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 449384699
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P54226c.json
+++ b/osFiles/bridgeOS/17x/17P54226c.json
@@ -15,5 +15,51 @@
         "iBridge2,10",
         "iBridge2,12",
         "iBridge2,14"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/41/53/061-73021-A_T65OUO1XSL/w2bpof3pz86onz0lxsw6m04etiztdgyzrj/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 444928254
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/58/02/061-64231-A_JF80NXWTFM/isxdf2hwzathu5gi5b5bo74hrmdfaiy5rf/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 444928250
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P54236b.json
+++ b/osFiles/bridgeOS/17x/17P54236b.json
@@ -15,5 +15,51 @@
         "iBridge2,10",
         "iBridge2,12",
         "iBridge2,14"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/53/44/061-77702-A_33NX2JY15K/7yx2504mc7tyi5zn73ckjgans2mw3q0prl/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 388108538
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/10/00/061-80291-A_N5TC7QLNTK/0xwz99tgiplnv6ujyies4nnsqm81crtvol/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 388108540
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P54244e.json
+++ b/osFiles/bridgeOS/17x/17P54244e.json
@@ -15,5 +15,29 @@
         "iBridge2,10",
         "iBridge2,12",
         "iBridge2,14"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/45/48/061-81249-A_XIY7QFC6KX/c5lt0pqp8cmmysu2iajl80s6f4ll7bojqh/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 331550974
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P54252a.json
+++ b/osFiles/bridgeOS/17x/17P54252a.json
@@ -15,5 +15,51 @@
         "iBridge2,10",
         "iBridge2,12",
         "iBridge2,14"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/33/34/061-83492-A_Y90VDO2C86/svhh7mvrks27q8rfu9mhrno33cc57yp295/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 331485436
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/43/28/061-85696-A_GFMLWSUDD7/r5bq2ij7qg3z8oudpfb6kgmgbhqxxijjbq/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 331485439
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P54257a.json
+++ b/osFiles/bridgeOS/17x/17P54257a.json
@@ -15,5 +15,29 @@
         "iBridge2,10",
         "iBridge2,12",
         "iBridge2,14"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/22/37/061-88011-A_H12YZHU1UG/8gqqghd89u1e2lzywdatjtovk1iqt1unnq/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 331288831
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P54261a.json
+++ b/osFiles/bridgeOS/17x/17P54261a.json
@@ -16,5 +16,30 @@
         "iBridge2,12",
         "iBridge2,14",
         "iBridge2,15"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/30/56/061-90645-A_A0SZFS2M6Y/0djqpspwe7oew25n2y0v04s7k195ynnc70/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 331878650
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P55254a.json
+++ b/osFiles/bridgeOS/17x/17P55254a.json
@@ -16,5 +16,53 @@
         "iBridge2,12",
         "iBridge2,14",
         "iBridge2,15"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/11/10/061-93326-A_C6SW2VLY0B/3uinrwtkvvs8vyilskhgpyo5zzysyap6wd/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 371069178
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/21/25/061-92063-A_9CADBMX8XI/1yr22r19m2uj8o9xso8b1ferg29uy693gy/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 371069182
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P55264c.json
+++ b/osFiles/bridgeOS/17x/17P55264c.json
@@ -16,5 +16,30 @@
         "iBridge2,12",
         "iBridge2,14",
         "iBridge2,15"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/05/18/061-97987-A_8NG5WULKEF/ohpt3yn48o4e9pkmgda7970yo4dcgpuf84/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 372576509
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P55274c.json
+++ b/osFiles/bridgeOS/17x/17P55274c.json
@@ -16,5 +16,30 @@
         "iBridge2,12",
         "iBridge2,14",
         "iBridge2,15"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/32/14/001-05846-A_T0MK6QM6Z2/i29vofhpm92k2t05ehvhgewlno8tyc3ugc/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 372445438
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P55284b.json
+++ b/osFiles/bridgeOS/17x/17P55284b.json
@@ -18,5 +18,32 @@
         "iBridge2,15",
         "iBridge2,16",
         "iBridge2,21"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,21"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/35/42/001-07382-A_73EQEQ2CC9/ed6icpccgubo78llprpqjc28gtxvbcbnvl/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 391319803
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P55289a.json
+++ b/osFiles/bridgeOS/17x/17P55289a.json
@@ -18,5 +18,32 @@
         "iBridge2,15",
         "iBridge2,16",
         "iBridge2,21"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,21"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/49/31/001-07787-A_AKK018M7U1/vavoffeve7xjjcfb46z86sfwla67q24mj3/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 391319807
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P5580.json
+++ b/osFiles/bridgeOS/17x/17P5580.json
@@ -54,6 +54,33 @@
                 "md5": "704586c22a521c68c0909f4597f3a781"
             },
             "size": 536321502
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/49/00/001-15220-A_HK1HKZEUZF/3dkax7b6431o5pjnsyiiu3njx4jz9c58hs/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 411439352
         }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P56035a.json
+++ b/osFiles/bridgeOS/17x/17P56035a.json
@@ -18,5 +18,32 @@
         "iBridge2,15",
         "iBridge2,16",
         "iBridge2,21"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,21"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/60/51/001-08766-A_PL52ITQ41G/4d66qs87jylqw1e4w7ba1v40ubofhmdilq/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 421073139
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P56045a.json
+++ b/osFiles/bridgeOS/17x/17P56045a.json
@@ -18,5 +18,32 @@
         "iBridge2,15",
         "iBridge2,16",
         "iBridge2,21"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,21"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/31/46/001-13496-A_56OO0YBCZD/60h781u0gboyvnf192qckp794c3a7czef2/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 382865661
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P56063a.json
+++ b/osFiles/bridgeOS/17x/17P56063a.json
@@ -19,5 +19,33 @@
         "iBridge2,16",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/40/16/001-24164-A_HYOMTTEDPC/cb2wu3ircve1wccj503sxa6x3judrqho9s/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 390271229
+        }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P6065.json
+++ b/osFiles/bridgeOS/17x/17P6065.json
@@ -52,6 +52,32 @@
                 "md5": "215bdcb9f574b399a173e571dbf3918f"
             },
             "size": 510314169
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/15/33/061-94409-A_AW1HE5BCYR/af1afs5g6uqe5cc4pdy3cee0rzcyibyor1/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 390271226
         }
     ]
 }

--- a/osFiles/bridgeOS/17x/17P6610.json
+++ b/osFiles/bridgeOS/17x/17P6610.json
@@ -56,6 +56,146 @@
                 "md5": "6402401cf75acb1f201e980713aa7496"
             },
             "size": 542052217
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/58/14/001-51038-A_EJKE9WBV2D/h7zrh6zf0kv13lyhe9i8qmygds68gicgs5/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 416682237
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/41/51/001-73002-A_WRHOPHHLA3/wt9h9ieu492d5iadokij8dvq8t2dzg5sgg/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 416682231
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/05/21/001-48424-A_LWC33T31W9/390vsepb43ifjj55iz4cj9wv8uv5e5ml4l/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 416682236
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/51/36/001-46037-A_8HAGITOEKO/2u8dqg0a61ssz6sff01boe2gpwtbe9yktx/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 416682244
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/23/23/001-36736-A_W4BBTR2JIY/qtxb93bsr7e3lwm1wzffrpoa5zv6mgiy6w/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 416682241
         }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P2561.json
+++ b/osFiles/bridgeOS/18x/18P2561.json
@@ -61,6 +61,34 @@
                 }
             ],
             "size": 572778375
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/11/17/001-79709-A_O49FG5PSSW/u6bzq2oteumrkby9vik00n7p5qlytdkbn5/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 443303285
         }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P3030.json
+++ b/osFiles/bridgeOS/18x/18P3030.json
@@ -53,6 +53,34 @@
                 }
             ],
             "size": 573866451
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/62/22/001-86593-A_HVW0AQC7CD/54mgf2enj7hms0inocw11fijxpvyu25ini/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 441891251
         }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P4346.json
+++ b/osFiles/bridgeOS/18x/18P4346.json
@@ -61,6 +61,122 @@
                 }
             ],
             "size": 574726611
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/59/61/071-05410-A_Y3MJ64PCTZ/fnd6fp3jn7e5gf2c1497dhrd0sb4h3nxpr/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 438425920
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/26/49/071-00825-A_2LE5KFA0H0/7aol2gju986xht0ywkeszjrouuh4mif6x7/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                },
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/59/03/001-97995-A_77NZXQ4N1U/xz1afwx6qt8juvlebmw3rxtt8dzrsr9c56/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 438425741
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/55/00/071-00444-A_TFVWMIQUS8/5tmpm75rj5ep7yuo8ibpkymv73qacunew9/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 438425925
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/42/00/001-63484-A_GKYKONDQRD/hb6qm3w42lfroqm7u2cw2fqfwtcj45ujy9/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 438425737
         }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P4347.json
+++ b/osFiles/bridgeOS/18x/18P4347.json
@@ -53,6 +53,62 @@
                 }
             ],
             "size": 574717972
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/09/11/071-14749-A_WY3BW3N671/yn0c09pq4utup7zh2f57yqst9czxo59zvl/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 440887036
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/24/01/071-08940-A_E5T3LMNL2D/aoes4mc385n28ypkkq8owefwt44eo09r5e/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 440887044
         }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P4556.json
+++ b/osFiles/bridgeOS/18x/18P4556.json
@@ -63,6 +63,96 @@
                 }
             ],
             "size": 599175969
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/35/63/071-32413-A_GYU5XXH0SS/urjnxe2jlc3ytkftjcufjhx4pgqboduwqe/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 465042848
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/03/22/071-29167-A_DSP3B6LMT1/5up0bgu22veapvaqkrxeujtwzjj1pjizy6/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 465042842
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/16/22/001-29946-A_7VL9CR3LXX/h0gabgwr454atx4rak6zsozgtm1wfog9h4/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 465042856
         }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P4663.json
+++ b/osFiles/bridgeOS/18x/18P4663.json
@@ -63,6 +63,36 @@
                 }
             ],
             "size": 599667951
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/29/25/071-00701-A_PC7MDOIPTD/4dw0q1ppzyylw7ithh7xfobdpp3as7c79m/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 465094759
         }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P4759a.json
+++ b/osFiles/bridgeOS/18x/18P4759a.json
@@ -64,6 +64,156 @@
                 "sha2-256": "f29778355175b48372839deaaed6222c350198865d48e17caea208ec1355957d"
             },
             "size": 600102161
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/55/49/071-97389-A_2ARHXH3EV1/2b3c2sbhvjovoizo0nr1dnw86yvkgxtamv/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 466011516
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/41/17/071-78713-A_AUQ3G4PPZE/dfd5y87b3wb2d18awl9xs3jnnjb60s9k7h/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 466011535
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/28/36/071-72771-A_6PRJ0LJ8LQ/ihkxs44tomlmpmbr3ahwifdvpi1u2hcdpz/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 466011536
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/38/41/071-71346-A_BSDU9B23WI/u82pw2cnuidq1bk82j43wuezyomalmj963/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 466011521
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/40/50/071-68857-A_CZNJGWEVRH/kur9v17faw709wn5g2t0eg8vvm4ljocknx/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 466011523
         }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P50310o.json
+++ b/osFiles/bridgeOS/18x/18P50310o.json
@@ -19,5 +19,58 @@
         "iBridge2,16",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/04/28/001-18400-A_9PR1LXEKFC/czmgv59ffn8j0u96xf2tu7tiu2ykcp3izt/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ]
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/03/30/001-23556-A_BY2PMYGXOZ/d1sfjlq0lhmp0774ps60canb1ie91t94k8/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 439176471
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P50335d.json
+++ b/osFiles/bridgeOS/18x/18P50335d.json
@@ -19,5 +19,33 @@
         "iBridge2,16",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/23/50/001-26281-A_SKA8R77O5T/f63ffyukctrfdvv33do0cbirpie1a78vl3/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 407437999
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P50347c.json
+++ b/osFiles/bridgeOS/18x/18P50347c.json
@@ -19,5 +19,59 @@
         "iBridge2,16",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/37/32/001-34230-A_O97NE9E748/jwyw32ey1bvq7c46xzrvldlxo38kmdvold/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 406611220
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/62/13/001-35032-A_8R6TI52SJO/czn472a52g0bioec0sjrkh6mbrnnqhwuro/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 406620545
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P50358b.json
+++ b/osFiles/bridgeOS/18x/18P50358b.json
@@ -21,5 +21,35 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/35/05/001-36812-A_UY29WKEWVT/ko17ec9cpdif0gzzvr5yyikctm1f3il6hz/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 446458405
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P50370a.json
+++ b/osFiles/bridgeOS/18x/18P50370a.json
@@ -21,5 +21,35 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/54/54/001-43961-A_8LVSOHER0O/azi3h4nv8m0zxgk0l48r296ur10avkqlnh/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 445981045
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P50380a.json
+++ b/osFiles/bridgeOS/18x/18P50380a.json
@@ -21,5 +21,63 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/28/11/001-47035-A_KTZRQEWRRF/i58hox2u1ijlvx8muy0sp9ra65ayydk85u/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 442174590
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/30/39/001-49906-A_10BVTZ87O0/lfr3502w2n3gr2zo2m4uenvedmuj1x6ban/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 442174582
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P50390a.json
+++ b/osFiles/bridgeOS/18x/18P50390a.json
@@ -21,5 +21,35 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/41/33/001-51049-A_J6S18RN4C5/thnu1a2531u78g0i7hn23ah3r8w4w48gmt/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 441239437
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P50402b.json
+++ b/osFiles/bridgeOS/18x/18P50402b.json
@@ -21,5 +21,35 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/37/28/001-59617-A_H0WVBT0PJ3/jue8zyhnr4qd7squzhxxovuhxepzadawkm/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 440968644
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P52551s.json
+++ b/osFiles/bridgeOS/18x/18P52551s.json
@@ -21,5 +21,35 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/16/13/001-58877-A_39XMCAVLFG/0dygc5fjj52xaox8r7c6n6niup2fe24a3y/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 441765045
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P52560a.json
+++ b/osFiles/bridgeOS/18x/18P52560a.json
@@ -21,5 +21,35 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/46/42/001-72556-A_V4SXMI7NM4/j1q4lf3nmrob29uqh9xp08tcjw4y7gd2q4/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 442317230
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P53017c.json
+++ b/osFiles/bridgeOS/18x/18P53017c.json
@@ -21,5 +21,63 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/26/09/001-82555-A_ETIDQPKBQF/03w1jmvesgrli1088ivfjcxhzfx8npkbqt/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 442131819
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/36/14/001-83599-A_1NKDJ292ZR/ptbrkx541t4bg8z9ipo75nvhkcdtfjqx5z/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 442131815
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P53026b.json
+++ b/osFiles/bridgeOS/18x/18P53026b.json
@@ -21,5 +21,35 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/48/23/001-84781-A_0KHVMODN8R/zry5azmib5pcab23g5z8v1zyjrqwhj5ei2/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 440785609
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P54330a.json
+++ b/osFiles/bridgeOS/18x/18P54330a.json
@@ -21,5 +21,63 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/19/16/001-89545-A_OBX5NDFCW6/xgzkvsc155thyj1yaq4zaihmidqkjfw194/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 440811410
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/05/42/001-77249-A_5G9EJHSN9H/fkhb6pmuao711sq5kbkehxaakj363zby7c/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 440811426
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P54343c.json
+++ b/osFiles/bridgeOS/18x/18P54343c.json
@@ -21,5 +21,35 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,12",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/19/29/001-95582-A_PBXJM755E0/b26cvknibpaouzoh5hmke46yogll06ba84/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 441451722
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P54515f.json
+++ b/osFiles/bridgeOS/18x/18P54515f.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/58/43/071-02783-A_EHZABADZGD/gl5ht5y8jll8v7qkk4765ru95ndmmvd35r/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 461149856
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P54529c.json
+++ b/osFiles/bridgeOS/18x/18P54529c.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/17/00/071-05220-A_XY8QE86HG3/g6cftp33tmwid7cmygznt5vizrqr67rjhr/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 456273746
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P54539d.json
+++ b/osFiles/bridgeOS/18x/18P54539d.json
@@ -23,5 +23,67 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/18/29/071-10159-A_WIY9WJ7OGI/dxxw36u3tcss60h8sp7dv53l2barevtxzl/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 461240579
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/42/57/071-07150-A_2IT4NKPRI3/hjno7koommlx4a7fh5wihhahgravjcooyf/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 461240570
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P54554a.json
+++ b/osFiles/bridgeOS/18x/18P54554a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/12/54/071-17618-A_RSWO8NJAX4/ldcdclw1y4gzp5ipg3l191k4v22llp0pak/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 461484467
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P54555a.json
+++ b/osFiles/bridgeOS/18x/18P54555a.json
@@ -23,5 +23,127 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/17/09/071-27948-A_XARDGTJVAJ/rj9yj9nkwir1n645pk1l2tvjdidb3r7643/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 461515583
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/18/19/071-25873-A_Q6DZ8IT66K/absrxh1c2tzfhuswyzk74k115x1x9kiaec/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 461515599
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/45/04/071-21345-A_UZFL8I7M26/ljxqrx2wd50zogdag3usgsiyj7kdrttdcy/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 461515592
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/24/57/071-20122-A_2XA8I0Q9FW/twhufi7qmjolnbsudx78rouh5l1s6v7mcd/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 461515584
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P54646b.json
+++ b/osFiles/bridgeOS/18x/18P54646b.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/60/26/071-29401-A_BTAO0AKEJ3/8e68jv2nbeljac66e9r8r9oe3s60dddy30/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 464929377
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P54655a.json
+++ b/osFiles/bridgeOS/18x/18P54655a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/46/56/071-37331-A_XTFSQWHT3R/3agmumbjwzw2mzxfm1nfgel9tw1vt6n29i/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 464734072
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P54662a.json
+++ b/osFiles/bridgeOS/18x/18P54662a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/58/60/071-38774-A_1GZMU1Y074/f0mgxwpsganennha3p6dx552r7bvaojdy0/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 464874318
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P54724b.json
+++ b/osFiles/bridgeOS/18x/18P54724b.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/03/28/071-66885-A_5EL1Q0HSX1/0384pw5208qpnp6esl6ukmhtzx9zm5d91v/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 464402069
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P54734a.json
+++ b/osFiles/bridgeOS/18x/18P54734a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/08/38/071-46119-A_P9V5J03IND/l37nh721e5gx6c85aetj2y4zbs2ciil1j0/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 465784866
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P54743a.json
+++ b/osFiles/bridgeOS/18x/18P54743a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/30/40/071-52239-A_GRKB18DC9Z/nwvhrzq1ymi71wmise104y551vc6vgmr5c/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 465169144
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P54753c.json
+++ b/osFiles/bridgeOS/18x/18P54753c.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/24/40/071-56145-A_2E4LR3L295/s3ht0d64tw6xzn6qlfwby2devfgsfvmn1w/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 465363395
+        }
     ]
 }

--- a/osFiles/bridgeOS/18x/18P54758a.json
+++ b/osFiles/bridgeOS/18x/18P54758a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/03/28/071-66885-A_5EL1Q0HSX1/0384pw5208qpnp6esl6ukmhtzx9zm5d91v/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 464402069
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P4242.json
+++ b/osFiles/bridgeOS/19x/19P4242.json
@@ -67,6 +67,36 @@
                 "sha2-256": "0c8d8786c2c2f354466d23dd612b5092286c59938363e34f750e8f8184fb2389"
             },
             "size": 629586500
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/08/54/071-08763-A_TJ9VXODE13/wd7y9i1q4lzjancmkc4mun1elicnd1qxh7/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 499915956
         }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P4243.json
+++ b/osFiles/bridgeOS/19x/19P4243.json
@@ -59,6 +59,36 @@
                 "sha2-256": "6d8ed4c65db87febe6ff9146e16b886124fbaadb8833d753140d82cf447d4a7c"
             },
             "size": 629550682
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/52/32/002-79221-A_ODVCIPEQ8Z/pm6npz56lk7dckhfz7ejmnok8mok2ianug/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 490890302
         }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P50264n.json
+++ b/osFiles/bridgeOS/19x/19P50264n.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/46/49/071-51841-A_1KNYB87SJG/c99zaxra6m6cbux10t5dkd7ps0u50ubu3e/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 468404242
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P50284g.json
+++ b/osFiles/bridgeOS/19x/19P50284g.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/09/26/071-59956-A_ZA4DKRAMHO/uvwtw4rcuqy65vendel1r24324nmh15ebw/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 469202040
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P50300d.json
+++ b/osFiles/bridgeOS/19x/19P50300d.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/11/14/071-63746-A_VHZVYCQ8U4/chbjkq58gplagkuc5jnxkz5qrul5n484b9/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 466808385
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P50310e.json
+++ b/osFiles/bridgeOS/19x/19P50310e.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/37/28/071-71545-A_DCJVO7WGX8/hkas5e3i9pkwmhy2q6nrzi6f9ut9h169lw/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 465830718
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P50321e.json
+++ b/osFiles/bridgeOS/19x/19P50321e.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/58/38/071-79807-A_MCZZ6IEICS/sk498qqvqtv52linxcs1q5mwx02fm0ldnu/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 466867062
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P50506a.json
+++ b/osFiles/bridgeOS/19x/19P50506a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/62/17/071-90565-A_ZMGTKDIY0H/cygn1j06aekiqylx8bi641tu0s4a3nze8h/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 466890691
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P50522d.json
+++ b/osFiles/bridgeOS/19x/19P50522d.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/32/46/002-02554-A_UP2J4MYI3A/8pospg2sdekqzf5t009wjdvjtwtmlr2fwj/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 467245057
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P50534d.json
+++ b/osFiles/bridgeOS/19x/19P50534d.json
@@ -23,5 +23,67 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/13/15/002-10091-A_BJDAO5D2TF/efsl3w3t0iri0zssf5qsw00oy8pbxv058z/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 466104099
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/50/36/002-03837-A_ER91HEDWHQ/m1shr9nj5j970qkay9jx7mdj1ort10oc0y/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 466104089
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P50542a.json
+++ b/osFiles/bridgeOS/19x/19P50542a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/63/48/002-12796-A_YPYMKLG7OV/2xi06siu48btml1l173hxt8busvozcjk4e/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 467204394
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P50547a.json
+++ b/osFiles/bridgeOS/19x/19P50547a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/22/41/002-17773-A_LA4ABL6T8O/eu559ll41elzq52s720iqv8096n6r3myz9/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 465965754
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P50621c.json
+++ b/osFiles/bridgeOS/19x/19P50621c.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/52/53/002-28343-A_M2R7VLNPAY/6echbiwbqfr50mbs2rkkumsb0obfphkzo3/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 467479000
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P50631c.json
+++ b/osFiles/bridgeOS/19x/19P50631c.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/30/55/002-30060-A_1Q7O1IO5M2/iadkw8xkc28jcqupuor7wvl63qk7o2zu4v/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 466420778
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P50639a.json
+++ b/osFiles/bridgeOS/19x/19P50639a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/32/41/002-32826-A_VQHIX2WAN0/k8otqkfnphkdxkpskhhdslnaj9g8bhmt2q/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 467254882
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P50645a.json
+++ b/osFiles/bridgeOS/19x/19P50645a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/38/27/002-37363-A_MX2845DU28/5we45tnrrbmg2bhjb7p07iqavctlfuoaix/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 466012146
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P5071.json
+++ b/osFiles/bridgeOS/19x/19P5071.json
@@ -67,6 +67,36 @@
                 "sha2-256": "caad7cccb99a98c094cae094761dcc7e015bb1015d65da84c919578cc1b0abf4"
             },
             "size": 629857961
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/50/33/012-06885-A_6BPDJD0KY1/3xydr0h8v76g2s52obn1dbz3gyu3rzh0dk/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 491764130
         }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P50725a.json
+++ b/osFiles/bridgeOS/19x/19P50725a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/12/05/002-44451-A_585Q5KQI9I/pbdyntcoeijkc6evxp6j1bers6uvu08yx8/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 466220697
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P50739a.json
+++ b/osFiles/bridgeOS/19x/19P50739a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/50/58/002-47659-A_RD9JTHTXF9/k5crucfdqk9phcwebn7zjdrx9zgtzy652y/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 467464265
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P54214d.json
+++ b/osFiles/bridgeOS/19x/19P54214d.json
@@ -23,5 +23,67 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/50/10/002-59534-A_7R6M9TR581/t3203qakjxzsfqbb8y2s28orubd6271eqw/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 491204957
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/20/21/002-38514-A_K4ZDZPNRNG/ztuvka09gs92wa85cw00n6qk7o3k7j7h4r/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 491204948
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P54224e.json
+++ b/osFiles/bridgeOS/19x/19P54224e.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/40/51/002-66222-A_IPPSLPBCVH/gtr97qeqs6c3ggojcs6xv33prme3zjqwyy/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 499775661
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P54230d.json
+++ b/osFiles/bridgeOS/19x/19P54230d.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/53/54/002-69997-A_EG49PAT5FV/hidrjm2cees6x9zvx1iuidkw4w1mnvgg3x/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 491065058
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P54240a.json
+++ b/osFiles/bridgeOS/19x/19P54240a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/63/11/002-71803-A_USK1DRF6W0/gmvhi4b52pctzc68uog3lvl1wmrhb3dj1i/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 490177007
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P54242a.json
+++ b/osFiles/bridgeOS/19x/19P54242a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/54/58/002-74573-A_9ZKZU8WKNT/h376m3xzvzj972varmbu9si9lxv8gcj0w0/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 490184455
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P548.json
+++ b/osFiles/bridgeOS/19x/19P548.json
@@ -67,6 +67,96 @@
                 "sha2-256": "90e3f240a04c6f88b66a79e365aa97c974f15c199fe71e83dfe0447c29132fcb"
             },
             "size": 605523692
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/28/47/071-78672-A_P1ZNG5EBGN/oso7ec9ajbrwtktw0djxazmbdid5s0lvlt/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 467510106
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/04/55/002-23776-A_GJZ0L6X7ZG/hj9sqp3sfop2qzfx9shjwvvkbp0qfjgq1q/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 467510114
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/05/40/002-23736-A_SQYTOH0BQ4/8hk2zl1t2f4caqmy07qcyato0te5p23l30/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 467510112
         }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P549.json
+++ b/osFiles/bridgeOS/19x/19P549.json
@@ -57,6 +57,36 @@
                 "sha2-256": "9b3fba00c7f819893bdb61b2264ae2d65a125dc69949818024dd6232ab1be8bd"
             },
             "size": 605533432
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/26/01/002-30508-A_012NOPWJIQ/90h9tgsc9r6om4ne4od11sancydpc49ao6/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 467503347
         }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P55048a.json
+++ b/osFiles/bridgeOS/19x/19P55048a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/61/36/002-85713-A_2MWSU4KW1Z/9680md6urqnucio57nente3bl3os9vyfdn/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 491208117
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P55058a.json
+++ b/osFiles/bridgeOS/19x/19P55058a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/26/15/002-87596-A_RYGBBOIB2T/6yv1eibmahzsdh4la398sxb0qgioox3run/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 499245459
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P55063a.json
+++ b/osFiles/bridgeOS/19x/19P55063a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/13/14/002-90018-A_BBVECZWKM3/v0tu0xl4zs5fzk6izm4f1ipdqbf8sjef6u/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 490239095
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P55070a.json
+++ b/osFiles/bridgeOS/19x/19P55070a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/40/00/002-95105-A_38BGJ2Y7WE/1b6iuufbcylzmgup4f9nugn5338b5ap21a/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 491010611
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P56027a.json
+++ b/osFiles/bridgeOS/19x/19P56027a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/56/07/002-93740-A_IFBB96DUOH/1g42s0my3m299dediq06lfmg9il58xv9ig/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 491279794
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P56037a.json
+++ b/osFiles/bridgeOS/19x/19P56037a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/57/04/012-10643-A_VEEP9D331W/utwaii424ta4du4a9dsulsk129smx1upfg/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 491367062
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P56046a.json
+++ b/osFiles/bridgeOS/19x/19P56046a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/17/45/012-18270-A_HUF7REYPRF/nxu9a7xn57od2o42p8b16bmvjz2ibmw2e6/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 491384852
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P56056a.json
+++ b/osFiles/bridgeOS/19x/19P56056a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/24/48/012-26453-A_LEA8KA5XME/obsr8fv4yy96btf9182azvwln1mi2uupmx/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 490530034
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P56062a.json
+++ b/osFiles/bridgeOS/19x/19P56062a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/34/28/012-36743-A_5XC4LDGB4E/3g9xpizp754rklixp35508llhttu5llie6/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 491182724
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P6063.json
+++ b/osFiles/bridgeOS/19x/19P6063.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/49/56/012-40369-A_9QUUUUAPG7/n1ntx9kogfte6k960bw9zsxnhmf60hla7r/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 500319097
+        }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P6064.json
+++ b/osFiles/bridgeOS/19x/19P6064.json
@@ -67,6 +67,36 @@
                 "sha2-256": "f9819bc5431b5b2969efa1f8c0fbd82676321c1a424f20a8e7f4dbd390b95e2a"
             },
             "size": 630053299
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/40/41/012-42712-A_1M1D81I7BB/w345yo83f490v9014vlfdo011ge2l7m14n/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 491874181
         }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P6066.json
+++ b/osFiles/bridgeOS/19x/19P6066.json
@@ -59,6 +59,36 @@
                 "sha2-256": "ee350551cc45556486fcd65d6afab342a391e98af747b01e8f1035888ff99ae3"
             },
             "size": 629996922
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/38/25/012-51689-A_VY6IPKR6Y7/wfqwio2zu28pehvv826jdbmltsw3tn6urt/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 491858909
         }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P6067.json
+++ b/osFiles/bridgeOS/19x/19P6067.json
@@ -68,6 +68,36 @@
                 "sha2-256": "528f2111dd5d03da06ab44a46143ab751f34a4bb84b23104db907dc6222b2d6e"
             },
             "size": 629964624
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/02/06/012-40525-A_46QQ4893AP/h7qoabxrnjkcz6y1lp029p84bhowqz181i/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 500103592
         }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P647.json
+++ b/osFiles/bridgeOS/19x/19P647.json
@@ -67,6 +67,66 @@
                 "sha2-256": "89b8a3feb0802dc075381876e8b0314139c145cbea057a677b043417c9235c6b"
             },
             "size": 605319774
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/52/39/071-93413-A_PA57I6ZCDC/7zfhdxwiko86nanizsofb9ni2ga4pzqxuk/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 467620861
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/58/55/002-42444-A_MRQ10PR1H1/1nfbd1kdiu053bpwygq2njk1x7rbclta2y/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 467620847
         }
     ]
 }

--- a/osFiles/bridgeOS/19x/19P744.json
+++ b/osFiles/bridgeOS/19x/19P744.json
@@ -67,6 +67,100 @@
                 "sha2-256": "9cef05ebe689d681c3f9f2d1900b5f16045f82d7481a6e37a9fcbada9a799b3f"
             },
             "size": 605282811
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/33/08/002-66267-A_9L1OAN5PVV/sx13rspugg77fu5aizmnh4tzcnkcbwz5o2/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 466458421
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/12/32/002-57037-A_N8028TDE8Z/3ocnlojukqop3keurcvv4t4r7yn5cc0r1u/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 466458405
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/03/61/002-55682-A_3GGADY4OLJ/yvpmaba8die2fwvlny4r800yz852sw6xra/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                },
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/43/09/002-20789-A_HWYC1CIBXV/ceps1xpx2e9fcz26ipjc9wdyphqr5emn9y/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 466458384
         }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P2059.json
+++ b/osFiles/bridgeOS/20x/20P2059.json
@@ -67,6 +67,36 @@
                 "sha2-256": "772e895ee9a2b3d566f16d1fcd42ed83377f708c86e0e4632a5b2de6ad9f0df4"
             },
             "size": 650830087
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/59/10/012-60278-A_GJQG4K1Q3X/b84y9x0azfc2n7kubjaasyxjotujjnqi94/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 501635735
         }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P3045.json
+++ b/osFiles/bridgeOS/20x/20P3045.json
@@ -67,6 +67,66 @@
                 "sha2-256": "16203f8e37d8e786ab29a7b09c97dbff3e5a1472a968d010e2e765c1f70606e6"
             },
             "size": 651046261
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/33/58/032-48337-A_456ZONYEZX/a8jaf1xum8cbhj1a6620mlatlporsw6av1/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 501811204
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/43/47/032-35710-A_4XUNTGCCKS/i33vwcz8anepkj8q82amgblxgjj52wris7/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 501811208
         }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P411.json
+++ b/osFiles/bridgeOS/20x/20P411.json
@@ -67,6 +67,66 @@
                 "sha2-256": "78a2e457fe01972c89c0845f5bd4e4c427217e612fe5ea1c962f033d1f413f45"
             },
             "size": 645710912
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/02/00/071-09020-A_IXBPNSGARO/z9v5h5vuu01m5io0p45bsw8ygf1c3gqmi5/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 503933194
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/47/11/012-92164-A_6SXMAY64P5/ezyovjncakcxzzbb9t3u195njz1rkwpyfj/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 503933193
         }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P420.json
+++ b/osFiles/bridgeOS/20x/20P420.json
@@ -59,6 +59,36 @@
                 "sha2-256": "527da09062e6ef54f45a29199b19b9ddfd14ec3051226b4de433eb3e8a002194"
             },
             "size": 645762354
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/37/47/012-93797-A_EAVFI5I53D/ufdgmh16d32s3fyxfgjjbzpl8ph3odn6t7/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 505140452
         }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P4252.json
+++ b/osFiles/bridgeOS/20x/20P4252.json
@@ -67,6 +67,66 @@
                 "sha2-256": "b57568b11ffad84793f660a698997f9f96385d3a6eaafdd42810d83be9d32d41"
             },
             "size": 652695072
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/26/46/032-66591-A_NO758JM9XG/0su9d09rm53vtspbxegbi81vq11l025jcq/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516821924
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/37/27/002-75542-A_PE8GK5TGD9/fidbwz256dslhpvrxv1ifgknhdbfv5yx3u/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516821916
         }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P50300m.json
+++ b/osFiles/bridgeOS/20x/20P50300m.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/25/09/012-20269-A_0DUZXTG8VO/1r8js0hrx71lzjvm8spzrr7dm52dclmx1c/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 502952372
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P50320f.json
+++ b/osFiles/bridgeOS/20x/20P50320f.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/46/05/012-30336-A_LZNC1GK1GM/dkwdsphrq9vn0d2p5kncrp45mz31f4u07t/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 503050508
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P50329e.json
+++ b/osFiles/bridgeOS/20x/20P50329e.json
@@ -23,5 +23,67 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/06/24/012-38310-A_TFM973HXNF/mggiqv5vm7a1a1dumihpm3d7tuljgzk6j9/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 503357775
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/26/35/012-38163-A_E4UK0FDT5B/hd9pskj90cfodyu5xti2qdks3ys5qkpd77/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 503357756
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P50345d.json
+++ b/osFiles/bridgeOS/20x/20P50345d.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/02/35/012-43300-A_81097NS9PZ/rpcd8zqj6zc57gjoq4oyxjgojo9fi3gfc8/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 502925415
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P50355d.json
+++ b/osFiles/bridgeOS/20x/20P50355d.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/22/56/012-51409-A_Z4QGTKPJGQ/8u4ywpqn2leo39m8elcaeboikpa1l51hg0/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 502678462
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P50365d.json
+++ b/osFiles/bridgeOS/20x/20P50365d.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/38/20/012-54800-A_PLDPH1PJVS/vp0p8cv1m7dsww9teyixldhxgv1ywp41rp/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 504547170
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P50376b.json
+++ b/osFiles/bridgeOS/20x/20P50376b.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/31/06/012-66748-A_DLD4CK6730/jauzr17dmtijgrvkjypa2idvb2t9wpzwb1/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 504703735
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P50386e.json
+++ b/osFiles/bridgeOS/20x/20P50386e.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/18/32/012-70777-A_O981ERR7GO/t3l61qjdvi2f2efyivne7b06edconj0a5r/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 503376413
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P50392d.json
+++ b/osFiles/bridgeOS/20x/20P50392d.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/14/59/012-71777-A_YVXMFKCQ0I/1xeiuf9yqnp5ru69of7jyelajta9x66vgx/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 504737338
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P50400b.json
+++ b/osFiles/bridgeOS/20x/20P50400b.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/03/13/012-83057-A_DQ5ULLN9YA/ox9pqgxy6mkbf3cew0rhpw88jsg2ep650w/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 504676140
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P50406a.json
+++ b/osFiles/bridgeOS/20x/20P50406a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/38/37/012-84566-A_LXHK9BE5X7/wykujmmqalg5b617fe9kzp1cv04v0dmdra/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 503156842
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P5058.json
+++ b/osFiles/bridgeOS/20x/20P5058.json
@@ -67,6 +67,96 @@
                 "sha2-256": "8d96e7b6e26843758f89cfa08bdbfb77d9b62005f6744eac933c2b576b80c97e"
             },
             "size": 652760644
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/41/42/032-84885-A_JDL38AHHF5/v2kg28hzvfheo66q2fy1fdy57xemqib5rg/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516755902
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/47/17/032-83928-A_SPJH7M6791/istiqy27rhnamchtpvd3lfsd8909zzb91t/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516755906
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/58/46/032-43945-A_29OZDV7562/mjewndhhwf1boe0ghaqcnxvlsb4lybovaj/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516755914
         }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P5060.json
+++ b/osFiles/bridgeOS/20x/20P5060.json
@@ -59,6 +59,36 @@
                 "sha2-256": "931b2f4a473ff47a2c49ad63ca995b3e83590540f1f4dc895e1f9ae7fcc1245e"
             },
             "size": 652704525
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/04/21/042-01890-A_EHRIU759GC/9ojyezkg3rb7o3z44sn1may3sg07g1hlui/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516746572
         }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P52032c.json
+++ b/osFiles/bridgeOS/20x/20P52032c.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/54/21/012-82065-A_FS6S9I7U4E/jhry0hukeodcorhwnco2feijftsyiygyk1/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 505023674
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P52043a.json
+++ b/osFiles/bridgeOS/20x/20P52043a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/51/29/032-02014-A_XS9WEAJF2K/4khm4xgsoape7rrsk3bvtn790hya55au58/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 501323818
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P52049a.json
+++ b/osFiles/bridgeOS/20x/20P52049a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/19/50/032-06250-A_XB5PK35BVO/edsh56mv9iw9kh77v62gsllv2ujluaqjpf/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 501660725
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P52055a.json
+++ b/osFiles/bridgeOS/20x/20P52055a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/26/09/032-08120-A_IE2SY5C23D/qfqpal50al91hwruaysjrqbrz9sv6fn56b/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 501659755
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P53026b.json
+++ b/osFiles/bridgeOS/20x/20P53026b.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/61/29/032-12736-A_ECW2SZIX56/pbwtgrdryxw6ck4aubuc34bbemyrgyghgl/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 501474399
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P53037h.json
+++ b/osFiles/bridgeOS/20x/20P53037h.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/08/46/032-33178-A_APX6Z11DN7/jm6wr2w2hoxdhg4ftovzfmadvxv9obmik8/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 512697507
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P54223e.json
+++ b/osFiles/bridgeOS/20x/20P54223e.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/41/28/032-01920-A_F3MTXETC17/ven5d21tozl8bg9g61y2aomfxlp5p5hl2c/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 517109714
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P54234c.json
+++ b/osFiles/bridgeOS/20x/20P54234c.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/14/62/032-54747-A_YVHDUC8BB4/sxctjoec34kxhe5vx1kfo56k8i2e15ztzl/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516627088
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P54240d.json
+++ b/osFiles/bridgeOS/20x/20P54240d.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/58/01/032-60404-A_7YDBJMH1RV/pyns6t6e9r1lujv0kl8whrf577rdwwivgi/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516551506
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P54250a.json
+++ b/osFiles/bridgeOS/20x/20P54250a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/00/38/032-63665-A_E0RCCZ30JM/8tioxu6cfprgpdt1nafxob26mgi4btdg2p/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516240437
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P55027c.json
+++ b/osFiles/bridgeOS/20x/20P55027c.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/63/32/032-69188-A_6RX3V32Y9A/o2lr4eml2lmltypf5aiox43kui8aew3uok/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516319686
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P55038c.json
+++ b/osFiles/bridgeOS/20x/20P55038c.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/54/55/032-69879-A_RTC6ZIYEZH/9x3rq7fwn6a17dk0j4pfyygx69tqma7bb4/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516713847
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P55049b.json
+++ b/osFiles/bridgeOS/20x/20P55049b.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/55/40/032-76658-A_5SDZNPBJGA/3bif7ka7c2o3qcckgw92hm5y45bvdc4clj/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516338543
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P55057a.json
+++ b/osFiles/bridgeOS/20x/20P55057a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/29/63/032-79557-A_G3AMT5DSA1/f8tic5rfeonev8b1lzrnirh8ju04twfw6q/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516419343
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P6072.json
+++ b/osFiles/bridgeOS/20x/20P6072.json
@@ -67,6 +67,96 @@
                 "sha2-256": "3aeaa542b9f68f81d1cc57d032342e9f22cba334e362e499e18fb33022963cfe"
             },
             "size": 652808148
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/16/10/042-25655-A_QH5M6XPTG7/abyy3motn4q17uzmqemkfxdmcrh6jq7p2c/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516284247
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/58/16/042-43691-A_5Q623EMD22/gqmuloq4jm1z3iw9xnw145plhlo2mhuxo4/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516284238
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/51/27/032-69604-A_PLGX1NTE07/8pl0nnpxwa66ga3donph0p0txfu27di1kf/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516284237
         }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P65027b.json
+++ b/osFiles/bridgeOS/20x/20P65027b.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/34/07/032-86179-A_5SDRVF29RD/1tywoytxm9ixulvpo638zfj1pqmnijyxg7/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516729339
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P66038b.json
+++ b/osFiles/bridgeOS/20x/20P66038b.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/09/17/032-92526-A_2KNPV5XAY8/pf72gvmnjw63vgn40521rc2mkb2dorydya/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516070222
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P66048d.json
+++ b/osFiles/bridgeOS/20x/20P66048d.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/44/60/032-93695-A_ZBX2BRNE2M/frbgnnksweh3fkbu23x8npxju6uc4jngpo/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516232025
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P66059a.json
+++ b/osFiles/bridgeOS/20x/20P66059a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/04/63/042-03207-A_NG8VMBTSKO/dzll5ue70sph6y4wlkrxqiocxbp0en4s5x/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 515997896
+        }
     ]
 }

--- a/osFiles/bridgeOS/20x/20P66071a.json
+++ b/osFiles/bridgeOS/20x/20P66071a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/52/06/042-09558-A_8AJ6K2C9I0/rj6lth6hvnusm5114ueuk7wk1hc4tdqc03/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 516056137
+        }
     ]
 }

--- a/osFiles/bridgeOS/21x/21P1069.json
+++ b/osFiles/bridgeOS/21x/21P1069.json
@@ -63,6 +63,73 @@
                 "sha2-256": "d0ab3253af046e082d9f61c13513dffcf32b73303e1f3bea884056b0196f35d6"
             },
             "size": 702482297
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/42/50/042-10891-A_6HEPAY2877/xoe249rqnsbx03km5031s8fwjugeje3nsy/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 546194758
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/47/24/042-89616-A_GATCR5PHME/8ul1bmrt3rvswjml3l0xn6z77ge7ubn2a1/BridgeOSUpdateCustomer.pkg",
+                    "active": true
+                },
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/01/25/042-86429-A_MN7M0HIDDY/noy7l1xsaf1yh8vziyjprrsg1adigolgp2/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "hashes": {
+                "sha1": "8296d0596ea4dc51c528fb80719060c9a5f02569"
+            },
+            "size": 546194759
         }
     ]
 }

--- a/osFiles/bridgeOS/21x/21P365.json
+++ b/osFiles/bridgeOS/21x/21P365.json
@@ -67,6 +67,69 @@
                 "sha2-256": "86b6ec4bcd433865d7fb445f873f7d4721c0c3aac65635057955445fcee80bd0"
             },
             "size": 701922990
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/14/56/042-54867-A_GGHXLS8KWY/tjjmbvr3erlu3kommdtk42t21zhox1yobt/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "hashes": {
+                "sha1": "47a0f30a143421cafcc6e144f95ddc5919b6d096"
+            },
+            "size": 546936409
+        },
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/36/55/002-81967-A_V1N5CQJTS6/wqmkve82b4uji23fgzwo9jp4vvy1st6yvx/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 546936415
         }
     ]
 }

--- a/osFiles/bridgeOS/21x/21P50287n.json
+++ b/osFiles/bridgeOS/21x/21P50287n.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/18/48/032-94345-A_BJW7AS5KN2/gq7jqk47qo582jmylgpduq7929a77eo5k1/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 540639959
+        }
     ]
 }

--- a/osFiles/bridgeOS/21x/21P50307f.json
+++ b/osFiles/bridgeOS/21x/21P50307f.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/05/12/032-95857-A_ON7L2VL2VP/waqeo2yhogvwyi7j2gu4iiornjena4q0n5/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 543127704
+        }
     ]
 }

--- a/osFiles/bridgeOS/21x/21P50318d.json
+++ b/osFiles/bridgeOS/21x/21P50318d.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/49/59/042-06325-A_YHB0V9FQOH/36suv45fup7phistettu7mqoowef08tss0/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 544763492
+        }
     ]
 }

--- a/osFiles/bridgeOS/21x/21P50318e.json
+++ b/osFiles/bridgeOS/21x/21P50318e.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/41/44/042-13877-A_K57TXWLY91/ai81i7tr4i0gvo7fhdupp4dwmpautl54es/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 544701131
+        }
     ]
 }

--- a/osFiles/bridgeOS/21x/21P50333c.json
+++ b/osFiles/bridgeOS/21x/21P50333c.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/62/38/042-16916-A_PPI0TVAL41/cpvigp9e61u8yabteyh1nap6yyjcaetxo9/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 545272537
+        }
     ]
 }

--- a/osFiles/bridgeOS/21x/21P50333d.json
+++ b/osFiles/bridgeOS/21x/21P50333d.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/53/58/042-25556-A_7VL6O6TILY/wjemaxus7ubka6c2twgth0rjxwvzxmnx5r/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 545235767
+        }
     ]
 }

--- a/osFiles/bridgeOS/21x/21P50345d.json
+++ b/osFiles/bridgeOS/21x/21P50345d.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/13/42/042-27181-A_3977AOIJPF/2hfetayjqwqny1vjh2tbxgtiuxzy01w5ja/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 546253883
+        }
     ]
 }

--- a/osFiles/bridgeOS/21x/21P50360a.json
+++ b/osFiles/bridgeOS/21x/21P50360a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/50/08/042-37827-A_M46B0WHV26/2lsnw3kcn9qa5fsjmlcovnrrmo5exk4ebp/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 546139828
+        }
     ]
 }

--- a/osFiles/bridgeOS/21x/21P50364a.json
+++ b/osFiles/bridgeOS/21x/21P50364a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/33/26/042-41493-A_BJV6P5AD2M/95odecssooqyxya8mwxlnb01l0gxz9ocbi/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 545120372
+        }
     ]
 }

--- a/osFiles/bridgeOS/21x/21P51045c.json
+++ b/osFiles/bridgeOS/21x/21P51045c.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/24/62/042-60183-A_RSQEIP1ITN/a78lerz94alg8rrbzkbz7v97hw57ua9be4/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 545664344
+        }
     ]
 }

--- a/osFiles/bridgeOS/21x/21P51056d.json
+++ b/osFiles/bridgeOS/21x/21P51056d.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/46/48/042-65899-A_U1JDBGFWKP/j5igvayjgbwrar3tx4h7c83ld4zmzbevqp/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 545454197
+        }
     ]
 }

--- a/osFiles/bridgeOS/21x/21P51066a.json
+++ b/osFiles/bridgeOS/21x/21P51066a.json
@@ -23,5 +23,37 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/26/37/042-73330-A_6UDEED63I4/w5ylf3r5f8nzulmte9lriqx8z3wfm5u04k/BridgeOSUpdateCustomer.pkg",
+                    "active": false
+                }
+            ],
+            "size": 546397315
+        }
     ]
 }

--- a/osFiles/bridgeOS/21x/21P52030c.json
+++ b/osFiles/bridgeOS/21x/21P52030c.json
@@ -23,5 +23,40 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/07/42/042-71099-A_YWOMV2NL8Y/n7qyb5rhmlv01xo9y9ijbqiqprpmd8f07g/BridgeOSUpdateCustomer.pkg",
+                    "active": true
+                }
+            ],
+            "hashes": {
+                "sha1": "00a9b029e9b8555571621de9d1f5e1bf4f9c364c"
+            },
+            "size": 547256978
+        }
     ]
 }

--- a/osFiles/bridgeOS/21x/21P52041d.json
+++ b/osFiles/bridgeOS/21x/21P52041d.json
@@ -23,5 +23,40 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "https://swcdn.apple.com/content/downloads/56/04/042-92139-A_HYEYWNNBCQ/vd7zj40dur9mq2j1vxuu0767q6u8y231ay/BridgeOSUpdateCustomer.pkg",
+                    "active": true
+                }
+            ],
+            "hashes": {
+                "sha1": "b6bc631becc82fc70326c511d261a1fedfa0657d"
+            },
+            "size": 547210795
+        }
     ]
 }

--- a/osFiles/bridgeOS/21x/21P52047d.json
+++ b/osFiles/bridgeOS/21x/21P52047d.json
@@ -23,5 +23,40 @@
         "iBridge2,20",
         "iBridge2,21",
         "iBridge2,22"
+    ],
+    "sources": [
+        {
+            "type": "pkg",
+            "deviceMap": [
+                "iBridge2,1",
+                "iBridge2,3",
+                "iBridge2,4",
+                "iBridge2,5",
+                "iBridge2,6",
+                "iBridge2,7",
+                "iBridge2,8",
+                "iBridge2,10",
+                "iBridge2,11",
+                "iBridge2,12",
+                "iBridge2,13",
+                "iBridge2,14",
+                "iBridge2,15",
+                "iBridge2,16",
+                "iBridge2,19",
+                "iBridge2,20",
+                "iBridge2,21",
+                "iBridge2,22"
+            ],
+            "links": [
+                {
+                    "url": "http://swcdn.apple.com/content/downloads/44/37/042-99544-A_KRCYH26L90/vsxnph7m25v7id9nlc9l6og4dcl6xyitjg/BridgeOSUpdateCustomer.pkg",
+                    "active": true
+                }
+            ],
+            "hashes": {
+                "sha1": "b439fc761f12d5e000cfe271e1f5c3c4f8372cd8"
+            },
+            "size": 546319769
+        }
     ]
 }

--- a/osFiles/macOS/19x - 10.15.x/19H15.json
+++ b/osFiles/macOS/19x - 10.15.x/19H15.json
@@ -2,7 +2,7 @@
     "osStr": "macOS",
     "version": "10.15.7 (Supplemental Update)",
     "build": "19H15",
-    "bridgeOSBuild": "18P52560a",
+    "bridgeOSBuild": "17P6610",
     "released": "2020-11-05",
     "releaseNotes": "https://support.apple.com/kb/DL2061",
     "securityNotes": "https://support.apple.com/HT211947",


### PR DESCRIPTION
High Sierra and Mojave links still required