### PR TITLE
Remove iPod Touch (2nd Generation) from quickpwn.js

### DIFF
--- a/jailbreakFiles/legacy/quickpwn.js
+++ b/jailbreakFiles/legacy/quickpwn.js
@@ -21,14 +21,12 @@ module.exports = {
         "5F136", // 2.1
         "5F137", // 2.1
         "5G77", // 2.2
-        "5G77a", // 2.2, iPod touch (2nd gen) only
         "5H11", // 2.2.1
       ],
       devices: [
         "iPhone1,1", // iPhone
         "iPhone1,2", // iPhone 3G
         "iPod1,1", // iPod touch
-        "iPod2,1", // iPod touch (2nd generation)
       ]
     },
   ]


### PR DESCRIPTION
iPod Touch (2nd Generation) was added to quickpwn.js in https://github.com/littlebyteorg/appledb/commit/b8f2f24f2fde121b9104a1079eafd02e8807d252 (CC @emiyl)
However:
1. https://theapplewiki.com/wiki/Jailbreak/2.x claims that quickpwn doesn't support the iPod Touch 2
2. https://theapplewiki.com/wiki/QuickPwn has a screenshot demonstrating that the iPod Touch 2 isn't supported (obviously it could have been later updated though)
3. https://theapplewiki.com/wiki/Jailbreak_Exploits#QuickPwn_(2.0_-_2.2.1) claims that QuickPwn uses pwnage and pwnage 2.0, which both can't exploit the iPod Touch 2
4. https://mega.nz/folder/k4FAXCIB#Fk7pxs6ikYzL3YBvAGX5ig/folder/50lHETyB hosts quickpwn:
a. I don't have a MacBook, but the MacOS archives all contain `QuickPwn\QuickPwn.app\Contents\Resources\FirmwareBundles` folders, which contain files for the `iPhone1,1`, `iPhone 1,2` and `iPod1,1`, but not for the `iPod2,1`.
b. The Windows archives:
i. some executables won't run but contain `Data\PwnmetheusBundles` with no `iPod 2,1` bundles
NOTE: those executables would probably run if I downgraded iTunes, but I don't have time to do that right now
ii. all the other files (including the readme files) clearly indicate that they don't support the iPod Touch 2


I did find one source claiming that quickpwn can be modified to support the iPod Touch 2 (https://forums.macrumors.com/threads/jailbreak-ipod-touch-2nd-gen-no-joke.609338/), but it's dodgy, and the file no longer exists (and the youtube video has been taken down due to a TOS violation)