### PR TITLE
Add JSON Schema for osFiles, and configure it in VS Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ out/
 .DS_STORE
 node_modules/
 .idea/
-.vscode/
 apple_token.txt
 import*.txt
 import*.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+    "json.schemas": [
+        {
+            "fileMatch": [
+                "/osFiles/audioOS/**/*.json",
+                "/osFiles/bridgeOS/**/*.json",
+                "/osFiles/embeddedOS/**/*.json",
+                "/osFiles/iOS/**/*.json",
+                "/osFiles/iPadOS/**/*.json",
+                "/osFiles/macOS/**/*.json",
+                "/osFiles/tvOS/**/*.json",
+                "/osFiles/visionOS/**/*.json",
+                "/osFiles/watchOS/**/*.json"
+            ],
+            "url": "./schemas/osFiles.json"
+        }
+    ]
+}

--- a/schemas/osFiles.json
+++ b/schemas/osFiles.json
@@ -6,20 +6,29 @@
     "type": "object",
     "additionalProperties": true,
     "properties": {
-        "osStr":        {"type": "string"},
-        "version":      {"type": "string"},
-        "build":        {"type": "string"},
-        "uniqueBuild":  {"type": "string"},
-        "buildTrain":   {"type": "string"},
+        "osStr":         {"type": "string"},
+        "version":       {"type": "string"},
+        "safariVersion": {
+            "anyOf": [
+                {"type": "string"},
+                {"type": "array", "items": {"type": "string"}}
+            ]
+        }
+        "build":         {"type": "string"},
+        "uniqueBuild":   {"type": "string"},
+        "key":           {"type": "string"},
         
         "bridgeOSBuild":    {"type": "string"},
         "embeddedOSBuild":  {"type": "string"},
+        "buildTrain":    {"type": "string"},
 
         "released":     {"type": "string"},
-        "beta":         {"type": "boolean"},
         "rc":           {"type": "boolean"},
+        "beta":         {"type": "boolean"},
+        "rsr":          {"type": "boolean"},
         "internal":     {"type": "boolean"},
         "hideFromLatestVersions": {"type": "boolean"},
+        "notes":        {"type": "string"},
         "releaseNotes": {"type": "string", "format": "uri"},
         "securityNotes":{"type": "string", "format": "uri"},
 
@@ -30,6 +39,12 @@
             ]
         },
         "deviceMap": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "osMap": {
             "type": "array",
             "items": {"type": "string"},
             "minItems": 1,
@@ -64,6 +79,7 @@
                 "align": {"type": "string"}
             }
         },
+        "appledbUrl": {"type": "string"},
         "sources": {
             "type": "array",
             "items": {

--- a/schemas/osFiles.json
+++ b/schemas/osFiles.json
@@ -1,0 +1,118 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Apple OS",
+    "description": "Description of an Apple operating system release",
+
+    "type": "object",
+    "additionalProperties": true,
+    "properties": {
+        "osStr":        {"type": "string"},
+        "version":      {"type": "string"},
+        "build":        {"type": "string"},
+        "uniqueBuild":  {"type": "string"},
+        "buildTrain":   {"type": "string"},
+        "sortVersion":  {"type": "string"},
+
+        "iosVersion":       {"type": "string"},
+        "bridgeOSBuild":    {"type": "string"},
+        "embeddedOSBuild":  {"type": "string"},
+
+        "released":     {"type": "string"},
+        "beta":         {"type": "boolean"},
+        "rc":           {"type": "boolean"},
+        "internal":     {"type": "boolean"},
+        "hideFromLatestVersions": {"type": "boolean"},
+        "releaseNotes": {"type": "string", "format": "uri"},
+        "securityNotes":{"type": "string", "format": "uri"},
+
+        "preinstalled": {
+            "anyOf": [
+                {"type": "boolean"},
+                {"type": "array", "items": {"type": "string"}}
+            ]
+        },
+        "deviceMap": {
+            "type": "array",
+            "items": {"type": "string"},
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "ipd": {
+            "type": "object",
+            "properties": {
+                "AudioAccessory": {"type": "string", "format": "uri"},
+                "AppleTV":  {"type": "string", "format": "uri"},
+                "iPhone":   {"type": "string", "format": "uri"},
+                "iPad":     {"type": "string", "format": "uri"},
+                "iPod":     {"type": "string", "format": "uri"}
+            },
+            "additionalProperties": {"type": "string", "format": "uri"}
+        },
+        "createDuplicateEntries": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "allOf": [
+                    {"$ref": "#"},
+                    {"properties": {"createDuplicateEntries": false}}
+                ]
+            }
+        },
+        "appledbWebImage": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "id": {"type": "string"},
+                "align": {"type": "string"}
+            }
+        },
+        "sources": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["type", "links", "deviceMap"],
+                "properties": {
+                    "type": {"enum": ["ipsw", "ota", "update", "kdk", "installassistant", "combo", "pkg"]},
+                    "deviceMap": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "minItems": 1,
+                        "uniqueItems": true
+                    },
+                    "hashes": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                            "md5":      { "type": "string", "pattern": "^[0-9a-f]{32}$" },
+                            "sha1":     { "type": "string", "pattern": "^[0-9a-f]{40}$" },
+                            "sha2-256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+                            "sha2-512": { "type": "string", "pattern": "^[0-9a-f]{128}$" }
+                        }
+                    },
+                    "links": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "required": ["url", "active"],
+                            "properties": {
+                                "url": {"type": "string", "format": "uri"},
+                                "active": {"type": "boolean"},
+                                "catalog": {"enum": ["dev-beta", "public-beta"]}
+                            }
+                        }
+                    },
+                    "prerequisiteBuild": {
+                        "anyOf": [
+                            {"type": "string"},
+                            {"type": "array", "minItems": 1, "items": {"type": "string"}}
+                        ]
+                    },
+                    "size": {"type": "integer"}
+                }
+            }
+        }
+    }
+}

--- a/schemas/osFiles.json
+++ b/schemas/osFiles.json
@@ -11,9 +11,7 @@
         "build":        {"type": "string"},
         "uniqueBuild":  {"type": "string"},
         "buildTrain":   {"type": "string"},
-        "sortVersion":  {"type": "string"},
-
-        "iosVersion":       {"type": "string"},
+        
         "bridgeOSBuild":    {"type": "string"},
         "embeddedOSBuild":  {"type": "string"},
 


### PR DESCRIPTION
You can validate JSON files in `osFiles` against the schema to find several kinds of errors. The vscode workspace settings file also tells VS Code to use this schema, which provides inline validation as you type, and code completion.

![image](https://github.com/littlebyteorg/appledb/assets/101955/0d371cb8-dcd4-4f93-ac68-3bbe1c49de29)

I'm only enabling it for actual OSs for now. Other files like `osFiles/Software/Safari` needs a lot more stuff added to the schema first.