### PR TITLE
Upgrade TetherBootX32 to semi-tethered

### DIFF
--- a/jailbreakFiles/legacy/tetherbootx32.js
+++ b/jailbreakFiles/legacy/tetherbootx32.js
@@ -6,7 +6,12 @@ module.exports = {
       url: "https://web.archive.org/web/20210322151359/https://dora2ios.web.app/tetherbootx32/",
       external: true
     },
-    type: "Tethered",
+    wiki: {
+      name: "theapplewiki.com/wiki/Tetherbootx32",
+      url: "https://theapplewiki.com/wiki/Tetherbootx32",
+      external: true
+    },
+    type: "Semi-tethered",
     firmwares: ["10.3.4","10.3.4"],
     soc: "A6",
     notes: "Only supports iPhone 5",


### PR DESCRIPTION
The official website considers the tool a semi-tether as of the March 2021 link (whereas it said tethered in the July 2020 archive), so we should upgrade its status to semi-tethered.