### PR TITLE
Update g1lbertJB priority

### DIFF
--- a/jailbreakFiles/legacy/absinthe.json
+++ b/jailbreakFiles/legacy/absinthe.json
@@ -1,6 +1,6 @@
 {
   "name": "Absinthe",
-  "priority": 0,
+  "priority": 1,
   "info": {
     "website": {
       "name": "greenpois0n.com/downloads (archive.org)",

--- a/jailbreakFiles/legacy/evasi0n.json
+++ b/jailbreakFiles/legacy/evasi0n.json
@@ -5,7 +5,7 @@
     "evasi0n6",
     "evasion6"
   ],
-  "priority": 0,
+  "priority": 1,
   "info": {
     "website": {
       "name": "theapplewiki.com/wiki/Evasi0n",

--- a/jailbreakFiles/legacy/g1lbertjb.json
+++ b/jailbreakFiles/legacy/g1lbertjb.json
@@ -1,6 +1,6 @@
 {
   "name": "g1lbertJB",
-  "priority": 1,
+  "priority": 0,
   "info": {
     "website": {
       "name": "github.com/g1lbertJB/g1lbertJB",


### PR DESCRIPTION
- Can simplify jailbreaking for iOS 5.0-6.1.2, especially in the case of iOS 5