### PR TITLE
Correct GPU and NE core counts for Mac13,2

### DIFF
--- a/deviceFiles/Mac Studio/Mac13,2.json
+++ b/deviceFiles/Mac Studio/Mac13,2.json
@@ -35,13 +35,10 @@
             ],
             "System_Level_Cache": "96MB",
             "GPU_Core_Count": [
-                24,
-                32,
                 48,
                 64
             ],
             "Neural_Engine_Core_Count": [
-                16,
                 32
             ]
         },

--- a/deviceFiles/Mac Studio/Mac13,2.json
+++ b/deviceFiles/Mac Studio/Mac13,2.json
@@ -39,7 +39,6 @@
                 64
             ],
             "Neural_Engine_Core_Count": 32
-            ]
         },
         {
             "type": "Memory",

--- a/deviceFiles/Mac Studio/Mac13,2.json
+++ b/deviceFiles/Mac Studio/Mac13,2.json
@@ -38,8 +38,7 @@
                 48,
                 64
             ],
-            "Neural_Engine_Core_Count": [
-                32
+            "Neural_Engine_Core_Count": 32
             ]
         },
         {


### PR DESCRIPTION
Remove 24 and 32 core GPU and 16 core Neural Engine. Source: https://support.apple.com/en-us/111900