### PR TITLE
Fix type/location for USB-C Magic Mous/Trackpad

### DIFF
--- a/deviceFiles/Mouse/Magic Mouse (USB-C).json
+++ b/deviceFiles/Mouse/Magic Mouse (USB-C).json
@@ -1,6 +1,6 @@
 {
     "name": "Magic Mouse (USB-C)",
-    "type": "Keyboard",
+    "type": "Mouse",
     "model": "A3204",
     "released": "2024-10-30"
 }

--- a/deviceFiles/Trackpad/Magic Trackpad (USB-C).json
+++ b/deviceFiles/Trackpad/Magic Trackpad (USB-C).json
@@ -1,6 +1,6 @@
 {
     "name": "Magic Trackpad (USB-C)",
-    "type": "Keyboard",
+    "type": "Trackpad",
     "model": "A3120",
     "released": "2024-10-30"
 }


### PR DESCRIPTION
I came across a few issues with the new USB-C Magic Mouse/Trackpad files which were inconsistent with previous versions, so have fixed them in this PR:

* Change type of `Magic Mouse (USB-C)` from `Keyboard` to `Mouse`
* Change type of `Magic Trackpad (USB-C)` from `Keyboard` to `Trackpad`
  * Also, move this file from `deviceFiles/Mouse` to `deviceFiles/Trackpad`