### PR TITLE
Correct typo unthreadera1n -> unthredera1n

### DIFF
--- a/jailbreakFiles/legacy/unthredera1n.json
+++ b/jailbreakFiles/legacy/unthredera1n.json
@@ -1,6 +1,6 @@
 {
-    "name": "unthreadera1n",
-    "alias": "unthreaderain",
+    "name": "unthredera1n",
+    "alias": "unthrederain",
     "info": {
         "wiki": {
             "name": "theapplewiki.com/wiki/Unthredera1n",


### PR DESCRIPTION
**Warning:** This is likely to cause previous links to this page to fail. If there is a proper protocol for this situation, do not merge this and implement this correction the proper way.

**Note:** This PR does not change the typo in the filename `/assets/images/jb-icons/unthreadera1n.png` because I'm unsure where it is