### PR TITLE
Update iPad7,6.json

### DIFF
--- a/deviceFiles/iPad/iPad7,6.json
+++ b/deviceFiles/iPad/iPad7,6.json
@@ -9,7 +9,7 @@
     "board": "J72bAP",
     "bdid": "0x1A",
     "model": "A1954",
-    "released": "2018-03-30",
+    "released": "2018-03-27",
     "discontinued": "2019-09-10",
     "colors": [
         {


### PR DESCRIPTION
That device released on March 27, 2018. Not March 30, 2018.