### PR TITLE
Update iPad7,5.json

### DIFF
--- a/deviceFiles/iPad/iPad7,5.json
+++ b/deviceFiles/iPad/iPad7,5.json
@@ -8,7 +8,7 @@
     "board": "J71bAP",
     "bdid": "0x18",
     "model": "A1893",
-    "released": "2018-03-30",
+    "released": "2018-03-27",
     "discontinued": "2019-09-10",
     "colors": [
         {


### PR DESCRIPTION
That device released on March 27, 2018. Not March 30, 2018.