### PR TITLE
IPSW of iOS 14.0 Beta (18A5301v) for iPhone11,8 & iPhone12,1 is inactive

### DIFF
--- a/osFiles/iOS/18x - 14.x/18A5301v.json
+++ b/osFiles/iOS/18x - 14.x/18A5301v.json
@@ -1016,7 +1016,7 @@
             "links": [
                 {
                     "url": "https://developer.apple.com/services-account/download?path=/WWDC_2020/iOS_14_beta/iPhone118iPhone121_14.0_18A5301v_Restore.ipsw",
-                    "active": true
+                    "active": false
                 }
             ],
             "size": 5588656437


### PR DESCRIPTION
I discovered (https://github.com/blacktop/ipsw/issues/1315) that the URL for downloading the IPSW of the iOS 14.0 for iPhone11,8 & iPhone12,1 is inactive